### PR TITLE
Add Codex backend support and fix agent layer bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ audit-output/
 
 bak/
 working/
+.omx/
+.omc/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # CodeAuditor
 
-A multi-stage, agentic code auditing pipeline built on the [Claude Code SDK](https://github.com/anthropics/claude-code-sdk-python). Given a target source tree, CodeAuditor researches project context, decomposes the codebase into analysis units, hunts for bugs, evaluates them as security vulnerabilities, reproduces them with a working PoC, and finally prepares a disclosure-ready report package.
+A multi-stage, agentic code auditing pipeline that can run on the [Claude Code SDK](https://github.com/anthropics/claude-code-sdk-python) or the [Codex App Server Python SDK](https://github.com/openai/codex/blob/main/sdk/python/README.md). Given a target source tree, CodeAuditor researches project context, decomposes the codebase into analysis units, hunts for bugs, evaluates them as security vulnerabilities, reproduces them with a working PoC, and finally prepares a disclosure-ready report package.
 
 CodeAuditor has discovered several CVEs in widely used open-source projects — see [Vulnerabilities found](#vulnerabilities-found) below.
 
 ## How it works
 
-The audit runs as seven sequential stages. Each stage is driven by a prompt template in `prompts/` and executed by one or more Claude Code agents. Outputs are validated, and on validation failure a repair prompt is sent (up to `max_retries`). Intermediate artifacts are written under the output directory; a `.markers/` folder tracks completed sub-tasks so runs can be resumed.
+The audit runs as seven sequential stages. Each stage is driven by a prompt template in `prompts/` and executed by one or more backend agents. Outputs are validated, and on validation failure a repair prompt is sent (up to `max_retries`). Intermediate artifacts are written under the output directory; a `.markers/` folder tracks completed sub-tasks so runs can be resumed.
 
 | Stage | What it does | Parallelism |
 |-------|--------------|-------------|
@@ -23,7 +23,8 @@ Stage 1 produces two directives — an *auditing focus* and *vulnerability crite
 ## Requirements
 
 - Python **3.12+**
-- A working [Claude Code](https://docs.claude.com/en/docs/claude-code) install (the SDK reuses its authentication)
+- A working [Claude Code](https://docs.claude.com/en/docs/claude-code) install for `--backend claude` (the SDK reuses its authentication)
+- A working Codex CLI at `/usr/local/bin/codex` with `codex app-server` support and local Codex auth/session for `--backend codex`
 - Git, plus whatever build tools the target project needs for Stage 5 reproduction
 
 ## Installation
@@ -49,7 +50,8 @@ code-auditor --target /path/to/project [options]
 | `--target` | **Required.** Root directory of the project to audit. |
 | `--output-dir` | Output directory (default: `{target}/audit-output`). |
 | `--max-parallel` | Max concurrent agents (default: `1`). |
-| `--model` | Claude model to use (default: `claude-sonnet-4-6`). |
+| `--backend` | Agent backend: `claude` or `codex` (default: `claude`). |
+| `--model` | Backend model override. Claude defaults to `claude-sonnet-4-6`; Codex uses the local Codex config default unless specified. |
 | `--target-au-count` | Target number of analysis units for Stage 2 (default: `10`). |
 | `--log-level` | `DEBUG` \| `INFO` \| `WARNING` \| `ERROR` (default: `INFO`). |
 
@@ -85,7 +87,7 @@ code_auditor/
 ├── __main__.py          # CLI entry point
 ├── config.py            # AuditConfig and dataclasses
 ├── orchestrator.py      # Sequential stage runner
-├── agent.py             # claude-code-sdk wrapper + validation retry loop
+├── agent.py             # Backend wrappers + validation retry loop
 ├── prompts.py           # Prompt loader with __KEY__ substitution
 ├── checkpoint.py        # Marker-based checkpoint/resume
 ├── logger.py            # Logging helper

--- a/code_auditor/__main__.py
+++ b/code_auditor/__main__.py
@@ -5,7 +5,7 @@ import asyncio
 import os
 import sys
 
-from .config import AuditConfig
+from .config import DEFAULT_BACKEND, DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL, AuditConfig
 from .logger import configure_logging, get_logger
 from .orchestrator import run_audit
 
@@ -20,7 +20,16 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--target", required=True, help="Root directory of the project to audit")
     parser.add_argument("--output-dir", help="Output directory (default: {target}/audit-output)")
     parser.add_argument("--max-parallel", type=int, default=1, help="Maximum concurrent agents (default: 1)")
-    parser.add_argument("--model", default="claude-sonnet-4-6", help="Claude model to use (default: claude-sonnet-4-6)")
+    parser.add_argument(
+        "--backend",
+        choices=["claude", "codex"],
+        default=DEFAULT_BACKEND,
+        help="Agent backend to use (default: claude)",
+    )
+    parser.add_argument(
+        "--model",
+        help=f"Backend model override (Claude default: {DEFAULT_CLAUDE_MODEL}; Codex default: {DEFAULT_CODEX_MODEL})",
+    )
     parser.add_argument("--target-au-count", type=int, default=10, help="Target number of analysis units for stage 2 (default: 10)")
     parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
     parser.add_argument(
@@ -50,6 +59,7 @@ def main() -> None:
         max_parallel=args.max_parallel,
         resume=True,
         log_level=args.log_level.upper(),
+        backend=args.backend,
         model=args.model,
         target_au_count=args.target_au_count,
         skip_stages=skip_stages,

--- a/code_auditor/agent.py
+++ b/code_auditor/agent.py
@@ -3,93 +3,109 @@ from __future__ import annotations
 import asyncio
 import os
 import subprocess
-from typing import Callable
+from typing import Callable, TextIO
 
-from claude_code_sdk import ClaudeCodeOptions, query
-from claude_code_sdk._internal import client as _sdk_client
-from claude_code_sdk._internal import message_parser as _mp
-from claude_code_sdk._errors import ProcessError as _ProcessError
-from claude_code_sdk._internal.transport import subprocess_cli as _transport
-
-from .config import AuditConfig, ValidationIssue
+from .config import DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL, AuditConfig, ValidationIssue
 from .logger import get_logger
 from .utils import format_validation_issues
 
 AGENT_MAX_RETRIES = 3
 AGENT_RETRY_BASE_DELAY = 10  # seconds
+DEFAULT_CODEX_BIN = "/usr/local/bin/codex"
 
 logger = get_logger("agent")
 
-# Patch SDK message parser to skip unknown message types instead of raising.
-# The installed SDK version (0.0.25) predates some newer event types
-# (e.g. rate_limit_event) emitted by the Claude Code backend.
-_original_parse_message = _mp.parse_message
+_claude_sdk_patched = False
 
 
-def _patched_parse_message(data):  # type: ignore[no-untyped-def]
-    try:
-        return _original_parse_message(data)
-    except Exception:
-        logger.debug("Skipping unknown SDK message type: %s", data.get("type", "?"))
-        return None
+def _patch_claude_sdk(sdk_client, mp, process_error, transport):  # type: ignore[no-untyped-def]
+    """Patch Claude SDK compatibility issues after the SDK is imported."""
+    # Patch SDK message parser to skip unknown message types instead of raising.
+    # The installed SDK version (0.0.25) predates some newer event types
+    # (e.g. rate_limit_event) emitted by the Claude Code backend.
+    original_parse_message = mp.parse_message
 
+    def patched_parse_message(data):  # type: ignore[no-untyped-def]
+        try:
+            return original_parse_message(data)
+        except Exception:
+            logger.debug("Skipping unknown SDK message type: %s", data.get("type", "?"))
+            return None
 
-# Patch both the module-level reference and the client module's imported copy.
-_mp.parse_message = _patched_parse_message
-_sdk_client.parse_message = _patched_parse_message
+    # Patch both the module-level reference and the client module's imported copy.
+    mp.parse_message = patched_parse_message
+    sdk_client.parse_message = patched_parse_message
 
-# Patch SubprocessCLITransport.connect to always capture stderr via PIPE,
-# and _read_messages_impl to include the captured stderr in the error message.
-_original_connect = _transport.SubprocessCLITransport.connect
-_original_read_messages_impl = _transport.SubprocessCLITransport._read_messages_impl
+    # Patch SubprocessCLITransport.connect to always capture stderr via PIPE,
+    # and _read_messages_impl to include the captured stderr in the error message.
+    original_connect = transport.SubprocessCLITransport.connect
+    original_read_messages_impl = transport.SubprocessCLITransport._read_messages_impl
 
-
-async def _patched_connect(self):  # type: ignore[no-untyped-def]
-    """Patched connect that forces stderr=PIPE so we can read error output."""
-    orig_debug_stderr = self._options.debug_stderr
-    # The SDK only captures stderr when BOTH debug_stderr is set AND
-    # "debug-to-stderr" is in extra_args.  We inject both temporarily
-    # so the subprocess is launched with stderr=PIPE, then restore the
-    # original values to avoid side-effects.
-    self._options.debug_stderr = subprocess.PIPE
-    had_debug_flag = "debug-to-stderr" in self._options.extra_args
-    if not had_debug_flag:
-        self._options.extra_args["debug-to-stderr"] = None
-
-    try:
-        await _original_connect(self)
-    finally:
-        self._options.debug_stderr = orig_debug_stderr
+    async def patched_connect(self):  # type: ignore[no-untyped-def]
+        """Patched connect that forces stderr=PIPE so we can read error output."""
+        orig_debug_stderr = self._options.debug_stderr
+        # The SDK only captures stderr when BOTH debug_stderr is set AND
+        # "debug-to-stderr" is in extra_args.  We inject both temporarily
+        # so the subprocess is launched with stderr=PIPE, then restore the
+        # original values to avoid side-effects.
+        self._options.debug_stderr = subprocess.PIPE
+        had_debug_flag = "debug-to-stderr" in self._options.extra_args
         if not had_debug_flag:
-            self._options.extra_args.pop("debug-to-stderr", None)
+            self._options.extra_args["debug-to-stderr"] = None
+
+        try:
+            await original_connect(self)
+        finally:
+            self._options.debug_stderr = orig_debug_stderr
+            if not had_debug_flag:
+                self._options.extra_args.pop("debug-to-stderr", None)
+
+    async def patched_read_messages_impl(self):  # type: ignore[no-untyped-def]
+        """Patched _read_messages_impl that captures stderr on failure."""
+        try:
+            async for message in original_read_messages_impl(self):
+                yield message
+        except process_error as exc:
+            # Try to read stderr for the real error details
+            stderr_text = ""
+            if self._process and self._process.stderr:
+                try:
+                    raw = await self._process.stderr.receive()
+                    stderr_text = raw.decode("utf-8", errors="replace").strip()
+                except Exception:
+                    pass
+            if stderr_text:
+                logger.error("Claude Code CLI stderr:\n%s", stderr_text)
+                raise process_error(
+                    f"{exc} — stderr: {stderr_text}",
+                    exit_code=exc.exit_code,
+                    stderr=stderr_text,
+                ) from exc
+            raise
+
+    transport.SubprocessCLITransport.connect = patched_connect
+    transport.SubprocessCLITransport._read_messages_impl = patched_read_messages_impl
 
 
-async def _patched_read_messages_impl(self):  # type: ignore[no-untyped-def]
-    """Patched _read_messages_impl that captures stderr on failure."""
+def _load_claude_sdk():  # type: ignore[no-untyped-def]
+    global _claude_sdk_patched
     try:
-        async for message in _original_read_messages_impl(self):
-            yield message
-    except _ProcessError as exc:
-        # Try to read stderr for the real error details
-        stderr_text = ""
-        if self._process and self._process.stderr:
-            try:
-                raw = await self._process.stderr.receive()
-                stderr_text = raw.decode("utf-8", errors="replace").strip()
-            except Exception:
-                pass
-        if stderr_text:
-            logger.error("Claude Code CLI stderr:\n%s", stderr_text)
-            raise _ProcessError(
-                f"{exc} — stderr: {stderr_text}",
-                exit_code=exc.exit_code,
-                stderr=stderr_text,
-            ) from exc
-        raise
+        from claude_code_sdk import ClaudeCodeOptions, query
+        from claude_code_sdk._errors import ProcessError
+        from claude_code_sdk._internal import client as sdk_client
+        from claude_code_sdk._internal import message_parser as mp
+        from claude_code_sdk._internal.transport import subprocess_cli as transport
+    except ImportError as exc:
+        raise RuntimeError(
+            "Claude backend requires the claude-code-sdk package. "
+            "Install project dependencies before using --backend claude."
+        ) from exc
 
+    if not _claude_sdk_patched:
+        _patch_claude_sdk(sdk_client, mp, ProcessError, transport)
+        _claude_sdk_patched = True
 
-_transport.SubprocessCLITransport.connect = _patched_connect  # type: ignore[assignment]
-_transport.SubprocessCLITransport._read_messages_impl = _patched_read_messages_impl  # type: ignore[assignment]
+    return ClaudeCodeOptions, query
 
 DEFAULT_TOOLS = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"]
 
@@ -104,7 +120,29 @@ def _additional_directories(config: AuditConfig, cwd: str) -> list[str]:
     return dirs
 
 
-async def run_agent(
+def _open_agent_log(log_file: str | None) -> TextIO | None:
+    if not log_file:
+        return None
+
+    log_dir = os.path.dirname(log_file)
+    if log_dir:
+        os.makedirs(log_dir, exist_ok=True)
+    log_fh = open(log_file, "a")  # noqa: SIM115
+    if log_fh.tell() > 0:
+        log_fh.write("\n--- new agent invocation ---\n\n")
+        log_fh.flush()
+    return log_fh
+
+
+def _resolve_codex_bin() -> str:
+    if not os.path.isfile(DEFAULT_CODEX_BIN):
+        raise RuntimeError(f"Codex CLI binary not found: {DEFAULT_CODEX_BIN}")
+    if not os.access(DEFAULT_CODEX_BIN, os.X_OK):
+        raise RuntimeError(f"Codex CLI binary is not executable: {DEFAULT_CODEX_BIN}")
+    return DEFAULT_CODEX_BIN
+
+
+async def _run_claude_agent(
     prompt: str,
     config: AuditConfig,
     cwd: str,
@@ -114,6 +152,7 @@ async def run_agent(
     effort: str | None = None,
     log_file: str | None = None,
 ) -> str:
+    ClaudeCodeOptions, query = _load_claude_sdk()
     tools = allowed_tools or DEFAULT_TOOLS
     add_dirs = _additional_directories(config, cwd)
 
@@ -130,19 +169,13 @@ async def run_agent(
         allowed_tools=tools,
         permission_mode="bypassPermissions",
         max_turns=max_turns,
-        model=model or config.model,
+        model=model or config.model or DEFAULT_CLAUDE_MODEL,
         cwd=cwd,
         add_dirs=add_dirs,
         extra_args=extra_args,
     )
 
-    log_fh = None
-    if log_file:
-        os.makedirs(os.path.dirname(log_file), exist_ok=True)
-        log_fh = open(log_file, "a")  # noqa: SIM115
-        if log_fh.tell() > 0:
-            log_fh.write("\n--- new agent invocation ---\n\n")
-            log_fh.flush()
+    log_fh = _open_agent_log(log_file)
 
     last_exc: Exception | None = None
     try:
@@ -182,6 +215,124 @@ async def run_agent(
             log_fh.close()
 
 
+async def _run_codex_agent(
+    prompt: str,
+    config: AuditConfig,
+    cwd: str,
+    allowed_tools: list[str] | None = None,
+    max_turns: int = 30,
+    model: str | None = None,
+    effort: str | None = None,
+    log_file: str | None = None,
+) -> str:
+    try:
+        from codex_app_server import (  # type: ignore[import-not-found]
+            AskForApproval,
+            AppServerConfig,
+            AsyncCodex,
+            ReasoningEffort,
+            SandboxPolicy,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "Codex backend requires the codex-app-server-sdk package. "
+            "Install project dependencies again after this change."
+        ) from exc
+
+    if allowed_tools is not None:
+        logger.debug("Codex backend does not map Claude allowed_tools directly; using Codex defaults.")
+    if max_turns != 30:
+        logger.debug("Codex backend runs one SDK turn per invocation; max_turns is not mapped directly.")
+
+    selected_model = model or config.model or DEFAULT_CODEX_MODEL
+    codex_bin = _resolve_codex_bin()
+    approval_policy = AskForApproval.model_validate("never")
+    sandbox_policy = SandboxPolicy.model_validate({"type": "dangerFullAccess"})
+    codex_effort = ReasoningEffort(effort) if effort else None
+
+    log_fh = _open_agent_log(log_file)
+    last_exc: Exception | None = None
+    try:
+        for attempt in range(AGENT_MAX_RETRIES):
+            try:
+                if log_fh and attempt > 0:
+                    log_fh.write(f"\n--- retry attempt {attempt + 1} ---\n\n")
+                    log_fh.flush()
+
+                app_server_config = AppServerConfig(codex_bin=codex_bin, cwd=cwd)
+                async with AsyncCodex(config=app_server_config) as codex:
+                    thread = await codex.thread_start(
+                        cwd=cwd,
+                        model=selected_model,
+                    )
+                    result = await thread.run(
+                        prompt,
+                        approval_policy=approval_policy,
+                        cwd=cwd,
+                        effort=codex_effort,
+                        model=selected_model,
+                        sandbox_policy=sandbox_policy,
+                    )
+
+                text = result.final_response or ""
+                if log_fh:
+                    log_fh.write(text)
+                    log_fh.write("\n")
+                    log_fh.flush()
+                return text
+            except Exception as exc:
+                last_exc = exc
+                if attempt < AGENT_MAX_RETRIES - 1:
+                    delay = AGENT_RETRY_BASE_DELAY * (2 ** attempt)
+                    logger.warning(
+                        "Codex agent call failed (attempt %d/%d), retrying in %ds: %s",
+                        attempt + 1, AGENT_MAX_RETRIES, delay, exc,
+                    )
+                    await asyncio.sleep(delay)
+                else:
+                    logger.error("Codex agent call failed after %d attempts: %s", AGENT_MAX_RETRIES, exc)
+
+        raise last_exc  # type: ignore[misc]
+    finally:
+        if log_fh and not log_fh.closed:
+            log_fh.close()
+
+
+async def run_agent(
+    prompt: str,
+    config: AuditConfig,
+    cwd: str,
+    allowed_tools: list[str] | None = None,
+    max_turns: int = 30,
+    model: str | None = None,
+    effort: str | None = None,
+    log_file: str | None = None,
+) -> str:
+    if config.backend == "codex":
+        return await _run_codex_agent(
+            prompt,
+            config,
+            cwd,
+            allowed_tools=allowed_tools,
+            max_turns=max_turns,
+            model=model,
+            effort=effort,
+            log_file=log_file,
+        )
+    if config.backend == "claude":
+        return await _run_claude_agent(
+            prompt,
+            config,
+            cwd,
+            allowed_tools=allowed_tools,
+            max_turns=max_turns,
+            model=model,
+            effort=effort,
+            log_file=log_file,
+        )
+    raise ValueError(f"Unsupported agent backend: {config.backend}")
+
+
 async def run_with_validation(
     prompt: str,
     config: AuditConfig,
@@ -217,6 +368,15 @@ async def run_with_validation(
             "Please fix all issues listed below, then save the corrected file.\n\n"
             f"Validation output:\n```\n{format_validation_issues(issues)}\n```"
         )
-        result = await run_agent(repair_prompt, config, cwd, allowed_tools, max_turns=10, log_file=log_file)
+        result = await run_agent(
+            repair_prompt,
+            config,
+            cwd,
+            allowed_tools,
+            max_turns=10,
+            model=model,
+            effort=effort,
+            log_file=log_file,
+        )
 
     return False, result

--- a/code_auditor/config.py
+++ b/code_auditor/config.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
+
+AgentBackend = Literal["claude", "codex"]
+
+DEFAULT_BACKEND: AgentBackend = "claude"
+DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6"
+DEFAULT_CLAUDE_POC_MODEL = "claude-opus-4-6"
+DEFAULT_CODEX_MODEL = "gpt-5.4"
 
 DEFAULT_THREAT_MODEL = (
     "Network attacker with full control over protocol messages. "
@@ -19,7 +27,8 @@ class AuditConfig:
     skip_stages: list[int] = field(default_factory=list)
     resume: bool = True
     log_level: str = "INFO"
-    model: str = "claude-sonnet-4-6"
+    backend: AgentBackend = DEFAULT_BACKEND
+    model: str | None = None
     target_au_count: int = 10
 
 

--- a/code_auditor/stages/stage5.py
+++ b/code_auditor/stages/stage5.py
@@ -7,7 +7,7 @@ import shutil
 
 from ..agent import run_agent
 from ..checkpoint import CheckpointManager
-from ..config import AuditConfig
+from ..config import DEFAULT_CLAUDE_POC_MODEL, AuditConfig
 from ..logger import get_logger
 from ..prompts import load_prompt
 from ..utils import run_parallel_limited
@@ -17,7 +17,6 @@ logger = get_logger("stage5")
 # Stage 5 agents need generous turn budgets — PoC development involves
 # building projects, writing exploit code, running/debugging, and iterating.
 _MAX_TURNS = 500
-_DEFAULT_MODEL = "claude-opus-4-6"
 _DEFAULT_EFFORT = "medium"
 _POC_TIMEOUT = 20 * 60  # 20 minutes
 
@@ -80,7 +79,7 @@ async def _run_reproduce(
             config,
             cwd=config.target,
             max_turns=_MAX_TURNS,
-            model=_DEFAULT_MODEL,
+            model=DEFAULT_CLAUDE_POC_MODEL if config.backend == "claude" else config.model,
             effort=_DEFAULT_EFFORT,
             log_file=log_file,
         )

--- a/code_auditor/stages/stage6.py
+++ b/code_auditor/stages/stage6.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from ..agent import run_agent
 from ..checkpoint import CheckpointManager
-from ..config import AuditConfig
+from ..config import DEFAULT_CLAUDE_POC_MODEL, AuditConfig
 from ..logger import get_logger
 from ..prompts import load_prompt
 from ..utils import run_parallel_limited
@@ -16,7 +16,6 @@ logger = get_logger("stage6")
 # Stage 6 agents verify reproduction, create minimal PoCs, and write
 # polished disclosure artifacts — similar complexity to Stage 5.
 _MAX_TURNS = 500
-_DEFAULT_MODEL = "claude-opus-4-6"
 _DEFAULT_EFFORT = "medium"
 _DISCLOSURE_TIMEOUT = 20 * 60  # 20 minutes
 
@@ -106,7 +105,7 @@ async def _run_disclosure(
             config,
             cwd=config.target,
             max_turns=_MAX_TURNS,
-            model=_DEFAULT_MODEL,
+            model=DEFAULT_CLAUDE_POC_MODEL if config.backend == "claude" else config.model,
             effort=_DEFAULT_EFFORT,
             log_file=log_file,
         )

--- a/code_auditor/tests/test_backend_selection.py
+++ b/code_auditor/tests/test_backend_selection.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from code_auditor import agent
+from code_auditor.__main__ import _build_parser
+from code_auditor.config import DEFAULT_BACKEND, AuditConfig
+
+
+def test_cli_backend_defaults_to_claude() -> None:
+    args = _build_parser().parse_args(["--target", "."])
+
+    assert args.backend == DEFAULT_BACKEND == "claude"
+    assert args.model is None
+
+
+def test_cli_accepts_codex_backend_and_model_override() -> None:
+    args = _build_parser().parse_args([
+        "--target",
+        ".",
+        "--backend",
+        "codex",
+        "--model",
+        "gpt-5.4",
+    ])
+
+    assert args.backend == "codex"
+    assert args.model == "gpt-5.4"
+
+
+def test_resolve_codex_bin_uses_default_path(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    codex_bin = tmp_path / "codex"
+    codex_bin.write_text("#!/bin/sh\n")
+    codex_bin.chmod(0o755)
+    monkeypatch.setattr(agent, "DEFAULT_CODEX_BIN", str(codex_bin))
+
+    assert agent._resolve_codex_bin() == str(codex_bin)
+
+
+def test_resolve_codex_bin_rejects_missing_default(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    missing = tmp_path / "missing-codex"
+    monkeypatch.setattr(agent, "DEFAULT_CODEX_BIN", str(missing))
+
+    with pytest.raises(RuntimeError, match="Codex CLI binary not found"):
+        agent._resolve_codex_bin()
+
+
+async def test_run_agent_dispatches_to_codex_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_codex_agent(*_args, **_kwargs) -> str:  # type: ignore[no-untyped-def]
+        return "codex-result"
+
+    async def fake_claude_agent(*_args, **_kwargs) -> str:  # type: ignore[no-untyped-def]
+        raise AssertionError("Claude backend should not be called")
+
+    monkeypatch.setattr(agent, "_run_codex_agent", fake_codex_agent)
+    monkeypatch.setattr(agent, "_run_claude_agent", fake_claude_agent)
+
+    config = AuditConfig(target="/tmp/project", output_dir="/tmp/output", backend="codex")
+
+    assert await agent.run_agent("prompt", config, cwd="/tmp/project") == "codex-result"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,18 @@ build-backend = "hatchling.build"
 [project]
 name = "code-auditor"
 version = "0.1.0"
-description = "Multi-stage code auditing agent application using Claude Code SDK"
+description = "Multi-stage code auditing agent application using Claude Code or Codex backends"
 requires-python = ">=3.12"
 dependencies = [
     "claude-code-sdk>=0.0.25",
+    "codex-app-server-sdk @ https://codeload.github.com/openai/codex/tar.gz/6e838a19fa52f2c30442c5bd2913acd1e6fe4c9d#subdirectory=sdk/python",
 ]
 
 [project.scripts]
 code-auditor = "code_auditor.__main__:main"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

- **Codex backend**: adds `--backend codex` flag wiring the full audit pipeline through `AsyncCodex` (codex-app-server-sdk). Default Codex model is `gpt-5.4`; overridable with `--model`.
- **Lazy Claude SDK loading**: `claude-code-sdk` is now imported on first use inside `_load_claude_sdk()`, so the package starts cleanly even when only the Codex backend is needed.
- **Bug fixes**:
  - `_open_agent_log`: guard `os.makedirs` against empty dirname (crash when `log_file` has no directory component).
  - Stage 5 & 6: replaced hardcoded `"claude-opus-4-6"` string with `DEFAULT_CLAUDE_POC_MODEL` constant; model is now selected per-backend at runtime.
  - Removed redundant `@pytest.mark.asyncio` decorator — `asyncio_mode = "auto"` in `pyproject.toml` applies it automatically.
- **New constants** in `config.py`: `AgentBackend`, `DEFAULT_BACKEND`, `DEFAULT_CODEX_MODEL`, `DEFAULT_CLAUDE_POC_MODEL`; `AuditConfig.model` is now `str | None`.
- **New tests**: `test_backend_selection.py` covers CLI defaults, backend dispatch, and codex-bin resolution (5 tests, all passing).
- **`pyproject.toml`**: adds `codex-app-server-sdk` dependency and `[tool.hatch.metadata] allow-direct-references = true`.
- **README** and **`.gitignore`** updated for the Codex backend and OMC directories.

## Test plan

- [x] `pytest code_auditor/tests/` — 20 passed
- [ ] Smoke-test `--backend claude` against a small target project
- [ ] Smoke-test `--backend codex --model gpt-5.4` against a small target project

🤖 Generated with [Claude Code](https://claude.com/claude-code)