### PR TITLE
Add Codex agent backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ audit-output/
 
 bak/
 working/
+.codex

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # CodeAuditor
 
-A multi-stage, agentic code auditing pipeline built on the [Claude Code SDK](https://github.com/anthropics/claude-code-sdk-python). Given a target source tree, CodeAuditor researches project context, decomposes the codebase into analysis units, hunts for bugs, evaluates them as security vulnerabilities, reproduces them with a working PoC, and finally prepares a disclosure-ready report package.
+A multi-stage, agentic code auditing pipeline with pluggable agent backends. CodeAuditor can run with the [Claude Code SDK](https://github.com/anthropics/claude-code-sdk-python) or the experimental Codex app-server Python SDK. Given a target source tree, it researches project context, decomposes the codebase into analysis units, hunts for bugs, evaluates them as security vulnerabilities, reproduces them with a working PoC, and finally prepares a disclosure-ready report package.
 
 CodeAuditor has discovered several CVEs in widely used open-source projects — see [Vulnerabilities found](#vulnerabilities-found) below.
 
 ## How it works
 
-The audit runs as seven sequential stages. Each stage is driven by a prompt template in `prompts/` and executed by one or more Claude Code agents. Outputs are validated, and on validation failure a repair prompt is sent (up to `max_retries`). Intermediate artifacts are written under the output directory; a `.markers/` folder tracks completed sub-tasks so runs can be resumed.
+The audit runs as seven sequential stages. Each stage is driven by a prompt template in `prompts/` and executed by one or more agent backend sessions. Outputs are validated, and on validation failure a repair prompt is sent (up to `max_retries`). Intermediate artifacts are written under the output directory; a `.markers/` folder tracks completed sub-tasks so runs can be resumed.
 
 | Stage | What it does | Parallelism |
 |-------|--------------|-------------|
@@ -23,7 +23,8 @@ Stage 1 produces two directives — an *auditing focus* and *vulnerability crite
 ## Requirements
 
 - Python **3.12+**
-- A working [Claude Code](https://docs.claude.com/en/docs/claude-code) install (the SDK reuses its authentication)
+- For the default backend: a working [Claude Code](https://docs.claude.com/en/docs/claude-code) install (the SDK reuses its authentication)
+- For the Codex backend: a working `codex` binary and `codex-app-server-sdk` installation, or a local `codex-main/sdk/python` checkout passed with `--codex-sdk-path`
 - Git, plus whatever build tools the target project needs for Stage 5 reproduction
 
 ## Installation
@@ -35,6 +36,19 @@ pip install -e .
 ```
 
 This exposes the `code-auditor` CLI entry point.
+
+For local Codex SDK development, install both projects into the same environment:
+
+```bash
+uv venv
+uv pip install -e . -e ../codex-main/sdk/python
+```
+
+Or install the optional Codex dependency directly from the OpenAI Codex repository:
+
+```bash
+pip install -e ".[codex]"
+```
 
 ## Usage
 
@@ -49,13 +63,16 @@ code-auditor --target /path/to/project [options]
 | `--target` | **Required.** Root directory of the project to audit. |
 | `--output-dir` | Output directory (default: `{target}/audit-output`). |
 | `--max-parallel` | Max concurrent agents (default: `1`). |
-| `--model` | Claude model to use (default: `claude-sonnet-4-6`). |
+| `--agent-backend` | Agent runtime backend: `claude-code` or `codex` (default: `claude-code`). |
+| `--model` | Agent model to use (default: `claude-sonnet-4-6` for Claude Code, `gpt-5.4` for Codex). |
 | `--target-au-count` | Target number of analysis units for Stage 2 (default: `10`). |
 | `--log-level` | `DEBUG` \| `INFO` \| `WARNING` \| `ERROR` (default: `INFO`). |
 
 Runs resume from checkpoint markers automatically — delete the output directory (or its `.markers/` subdirectory) to start a fresh audit.
 
-### Example
+Run `code-auditor --help` for backend-specific options, including Codex binary, SDK path, sandbox, network, and writable-root controls.
+
+### Claude Code example
 
 ```bash
 code-auditor \
@@ -64,6 +81,23 @@ code-auditor \
   --max-parallel 4 \
   --log-level DEBUG
 ```
+
+### Codex example
+
+```bash
+code-auditor \
+  --target ~/projects/libfoo \
+  --output-dir ~/audits/libfoo \
+  --agent-backend codex \
+  --codex-bin /usr/local/bin/codex \
+  --audit-only \
+  --max-parallel 1 \
+  --log-level DEBUG
+```
+
+The Codex backend starts a Codex app-server session per agent task. Transient stream, TLS, timeout, and network disconnect failures are retried. If a Codex turn finally completes with a failed status, the backend raises an error instead of silently treating the missing output as a filtered vulnerability; this prevents failed Stage 4 evaluations from being checkpointed as complete.
+
+Codex currently works best from an ASCII-only workspace path. Some Codex stream metadata paths may fail when the repository path contains non-ASCII characters.
 
 ## Output layout
 
@@ -85,7 +119,8 @@ code_auditor/
 ├── __main__.py          # CLI entry point
 ├── config.py            # AuditConfig and dataclasses
 ├── orchestrator.py      # Sequential stage runner
-├── agent.py             # claude-code-sdk wrapper + validation retry loop
+├── agent.py             # Backend selection + validation retry loop
+├── agent_backends/      # Claude Code and Codex agent runtime adapters
 ├── prompts.py           # Prompt loader with __KEY__ substitution
 ├── checkpoint.py        # Marker-based checkpoint/resume
 ├── logger.py            # Logging helper
@@ -105,7 +140,7 @@ pytest code_auditor/tests    # same thing
 pytest -k stage2             # filter by name
 ```
 
-Tests cover parsers and validators; they do not make real agent calls.
+Tests cover parsers, validators, and backend selection helpers; they do not make real agent calls.
 
 ## Vulnerabilities found
 

--- a/code_auditor/__main__.py
+++ b/code_auditor/__main__.py
@@ -5,7 +5,7 @@ import asyncio
 import os
 import sys
 
-from .config import AuditConfig
+from .config import DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL, AuditConfig
 from .logger import configure_logging, get_logger
 from .orchestrator import run_audit
 
@@ -20,9 +20,37 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--target", required=True, help="Root directory of the project to audit")
     parser.add_argument("--output-dir", help="Output directory (default: {target}/audit-output)")
     parser.add_argument("--max-parallel", type=int, default=1, help="Maximum concurrent agents (default: 1)")
-    parser.add_argument("--model", default="claude-sonnet-4-6", help="Claude model to use (default: claude-sonnet-4-6)")
+    parser.add_argument("--model", help="Agent model to use (default depends on --agent-backend)")
     parser.add_argument("--target-au-count", type=int, default=10, help="Target number of analysis units for stage 2 (default: 10)")
     parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    parser.add_argument(
+        "--agent-backend",
+        default="claude-code",
+        choices=["claude-code", "codex"],
+        help="Agent runtime backend (default: claude-code)",
+    )
+    parser.add_argument("--codex-bin", help="Path to a codex binary for the Codex app-server backend")
+    parser.add_argument(
+        "--codex-sdk-path",
+        help="Path to codex-main/sdk/python or an installed SDK source directory for local Codex SDK use",
+    )
+    parser.add_argument(
+        "--codex-sandbox",
+        default="workspace-write",
+        choices=["read-only", "workspace-write", "danger-full-access"],
+        help="Codex sandbox mode (default: workspace-write)",
+    )
+    parser.add_argument(
+        "--codex-network-access",
+        action="store_true",
+        help="Allow network access for Codex workspace-write/read-only sandbox policies",
+    )
+    parser.add_argument(
+        "--codex-extra-writable-root",
+        action="append",
+        default=[],
+        help="Additional writable root for the Codex workspace-write sandbox; may be repeated",
+    )
     parser.add_argument(
         "--audit-only",
         action="store_true",
@@ -41,6 +69,7 @@ def main() -> None:
         sys.exit(1)
 
     output_dir = os.path.realpath(args.output_dir or os.path.join(target, "audit-output"))
+    model = args.model or (DEFAULT_CODEX_MODEL if args.agent_backend == "codex" else DEFAULT_CLAUDE_MODEL)
 
     skip_stages = [5, 6] if args.audit_only else []
 
@@ -50,9 +79,15 @@ def main() -> None:
         max_parallel=args.max_parallel,
         resume=True,
         log_level=args.log_level.upper(),
-        model=args.model,
+        model=model,
         target_au_count=args.target_au_count,
         skip_stages=skip_stages,
+        agent_backend=args.agent_backend,
+        codex_bin=args.codex_bin,
+        codex_sdk_path=os.path.realpath(args.codex_sdk_path) if args.codex_sdk_path else None,
+        codex_sandbox=args.codex_sandbox,
+        codex_network_access=args.codex_network_access,
+        codex_extra_writable_roots=[os.path.realpath(p) for p in args.codex_extra_writable_root],
     )
 
     configure_logging(config.log_level)

--- a/code_auditor/agent.py
+++ b/code_auditor/agent.py
@@ -1,107 +1,28 @@
 from __future__ import annotations
 
-import asyncio
 import os
-import subprocess
 from typing import Callable
 
-from claude_code_sdk import ClaudeCodeOptions, query
-from claude_code_sdk._internal import client as _sdk_client
-from claude_code_sdk._internal import message_parser as _mp
-from claude_code_sdk._errors import ProcessError as _ProcessError
-from claude_code_sdk._internal.transport import subprocess_cli as _transport
-
+from .agent_backends import AgentBackend
 from .config import AuditConfig, ValidationIssue
 from .logger import get_logger
 from .utils import format_validation_issues
 
-AGENT_MAX_RETRIES = 3
-AGENT_RETRY_BASE_DELAY = 10  # seconds
-
 logger = get_logger("agent")
 
-# Patch SDK message parser to skip unknown message types instead of raising.
-# The installed SDK version (0.0.25) predates some newer event types
-# (e.g. rate_limit_event) emitted by the Claude Code backend.
-_original_parse_message = _mp.parse_message
 
+def _get_backend(config: AuditConfig) -> AgentBackend:
+    if config.agent_backend == "claude-code":
+        from .agent_backends.claude_code import ClaudeCodeBackend
 
-def _patched_parse_message(data):  # type: ignore[no-untyped-def]
-    try:
-        return _original_parse_message(data)
-    except Exception:
-        logger.debug("Skipping unknown SDK message type: %s", data.get("type", "?"))
-        return None
+        return ClaudeCodeBackend()
 
+    if config.agent_backend == "codex":
+        from .agent_backends.codex import CodexBackend
 
-# Patch both the module-level reference and the client module's imported copy.
-_mp.parse_message = _patched_parse_message
-_sdk_client.parse_message = _patched_parse_message
+        return CodexBackend()
 
-# Patch SubprocessCLITransport.connect to always capture stderr via PIPE,
-# and _read_messages_impl to include the captured stderr in the error message.
-_original_connect = _transport.SubprocessCLITransport.connect
-_original_read_messages_impl = _transport.SubprocessCLITransport._read_messages_impl
-
-
-async def _patched_connect(self):  # type: ignore[no-untyped-def]
-    """Patched connect that forces stderr=PIPE so we can read error output."""
-    orig_debug_stderr = self._options.debug_stderr
-    # The SDK only captures stderr when BOTH debug_stderr is set AND
-    # "debug-to-stderr" is in extra_args.  We inject both temporarily
-    # so the subprocess is launched with stderr=PIPE, then restore the
-    # original values to avoid side-effects.
-    self._options.debug_stderr = subprocess.PIPE
-    had_debug_flag = "debug-to-stderr" in self._options.extra_args
-    if not had_debug_flag:
-        self._options.extra_args["debug-to-stderr"] = None
-
-    try:
-        await _original_connect(self)
-    finally:
-        self._options.debug_stderr = orig_debug_stderr
-        if not had_debug_flag:
-            self._options.extra_args.pop("debug-to-stderr", None)
-
-
-async def _patched_read_messages_impl(self):  # type: ignore[no-untyped-def]
-    """Patched _read_messages_impl that captures stderr on failure."""
-    try:
-        async for message in _original_read_messages_impl(self):
-            yield message
-    except _ProcessError as exc:
-        # Try to read stderr for the real error details
-        stderr_text = ""
-        if self._process and self._process.stderr:
-            try:
-                raw = await self._process.stderr.receive()
-                stderr_text = raw.decode("utf-8", errors="replace").strip()
-            except Exception:
-                pass
-        if stderr_text:
-            logger.error("Claude Code CLI stderr:\n%s", stderr_text)
-            raise _ProcessError(
-                f"{exc} — stderr: {stderr_text}",
-                exit_code=exc.exit_code,
-                stderr=stderr_text,
-            ) from exc
-        raise
-
-
-_transport.SubprocessCLITransport.connect = _patched_connect  # type: ignore[assignment]
-_transport.SubprocessCLITransport._read_messages_impl = _patched_read_messages_impl  # type: ignore[assignment]
-
-DEFAULT_TOOLS = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"]
-
-
-def _additional_directories(config: AuditConfig, cwd: str) -> list[str]:
-    resolved_cwd = os.path.realpath(cwd)
-    dirs: list[str] = []
-    for candidate in [config.output_dir]:
-        resolved = os.path.realpath(candidate)
-        if resolved != resolved_cwd and os.path.isdir(resolved) and resolved not in dirs:
-            dirs.append(resolved)
-    return dirs
+    raise ValueError(f"Unsupported agent backend: {config.agent_backend}")
 
 
 async def run_agent(
@@ -114,72 +35,17 @@ async def run_agent(
     effort: str | None = None,
     log_file: str | None = None,
 ) -> str:
-    tools = allowed_tools or DEFAULT_TOOLS
-    add_dirs = _additional_directories(config, cwd)
-
-    extra_args: dict[str, str | None] = {
-        # Run sub-agents like a clean Claude Code install: no user/project
-        # settings, no plugins, no hooks, no CLAUDE.md, no slash commands.
-        "setting-sources": "",
-        "disable-slash-commands": None,
-    }
-    if effort:
-        extra_args["effort"] = effort
-
-    options = ClaudeCodeOptions(
-        allowed_tools=tools,
-        permission_mode="bypassPermissions",
-        max_turns=max_turns,
-        model=model or config.model,
+    backend = _get_backend(config)
+    return await backend.run(
+        prompt=prompt,
+        config=config,
         cwd=cwd,
-        add_dirs=add_dirs,
-        extra_args=extra_args,
+        allowed_tools=allowed_tools,
+        max_turns=max_turns,
+        model=model,
+        effort=effort,
+        log_file=log_file,
     )
-
-    log_fh = None
-    if log_file:
-        os.makedirs(os.path.dirname(log_file), exist_ok=True)
-        log_fh = open(log_file, "a")  # noqa: SIM115
-        if log_fh.tell() > 0:
-            log_fh.write("\n--- new agent invocation ---\n\n")
-            log_fh.flush()
-
-    last_exc: Exception | None = None
-    try:
-        for attempt in range(AGENT_MAX_RETRIES):
-            try:
-                text_parts: list[str] = []
-                if log_fh and attempt > 0:
-                    log_fh.write(f"\n--- retry attempt {attempt + 1} ---\n\n")
-                    log_fh.flush()
-                async for message in query(prompt=prompt, options=options):
-                    if message is None:
-                        continue
-                    if hasattr(message, "content"):
-                        for block in message.content:
-                            if hasattr(block, "text"):
-                                text_parts.append(block.text)
-                                if log_fh:
-                                    log_fh.write(block.text)
-                                    log_fh.write("\n")
-                                    log_fh.flush()
-                return "\n".join(text_parts)
-            except Exception as exc:
-                last_exc = exc
-                if attempt < AGENT_MAX_RETRIES - 1:
-                    delay = AGENT_RETRY_BASE_DELAY * (2 ** attempt)
-                    logger.warning(
-                        "Agent call failed (attempt %d/%d), retrying in %ds: %s",
-                        attempt + 1, AGENT_MAX_RETRIES, delay, exc,
-                    )
-                    await asyncio.sleep(delay)
-                else:
-                    logger.error("Agent call failed after %d attempts: %s", AGENT_MAX_RETRIES, exc)
-
-        raise last_exc  # type: ignore[misc]
-    finally:
-        if log_fh and not log_fh.closed:
-            log_fh.close()
 
 
 async def run_with_validation(
@@ -197,7 +63,16 @@ async def run_with_validation(
     log_file: str | None = None,
 ) -> tuple[bool, str]:
     """Run agent then validate output, retrying on failure. Returns (passed, result)."""
-    result = await run_agent(prompt, config, cwd, allowed_tools, max_turns, model=model, effort=effort, log_file=log_file)
+    result = await run_agent(
+        prompt,
+        config,
+        cwd,
+        allowed_tools,
+        max_turns,
+        model=model,
+        effort=effort,
+        log_file=log_file,
+    )
 
     for attempt in range(max_retries + 1):
         if skip_if_missing and not os.path.exists(output_path):
@@ -217,6 +92,13 @@ async def run_with_validation(
             "Please fix all issues listed below, then save the corrected file.\n\n"
             f"Validation output:\n```\n{format_validation_issues(issues)}\n```"
         )
-        result = await run_agent(repair_prompt, config, cwd, allowed_tools, max_turns=10, log_file=log_file)
+        result = await run_agent(
+            repair_prompt,
+            config,
+            cwd,
+            allowed_tools,
+            max_turns=10,
+            log_file=log_file,
+        )
 
     return False, result

--- a/code_auditor/agent_backends/__init__.py
+++ b/code_auditor/agent_backends/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .base import AgentBackend
+
+__all__ = ["AgentBackend"]

--- a/code_auditor/agent_backends/base.py
+++ b/code_auditor/agent_backends/base.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..config import AuditConfig
+
+
+class AgentBackend(Protocol):
+    async def run(
+        self,
+        prompt: str,
+        config: AuditConfig,
+        cwd: str,
+        allowed_tools: list[str] | None = None,
+        max_turns: int = 30,
+        model: str | None = None,
+        effort: str | None = None,
+        log_file: str | None = None,
+    ) -> str:
+        """Run one agent task and return collected assistant text."""

--- a/code_auditor/agent_backends/claude_code.py
+++ b/code_auditor/agent_backends/claude_code.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+
+from claude_code_sdk import ClaudeCodeOptions, query
+from claude_code_sdk._errors import ProcessError as _ProcessError
+from claude_code_sdk._internal import client as _sdk_client
+from claude_code_sdk._internal import message_parser as _mp
+from claude_code_sdk._internal.transport import subprocess_cli as _transport
+
+from ..config import AuditConfig
+from ..logger import get_logger
+
+AGENT_MAX_RETRIES = 3
+AGENT_RETRY_BASE_DELAY = 10  # seconds
+DEFAULT_TOOLS = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"]
+
+logger = get_logger("agent.claude_code")
+
+_PATCHED = False
+
+
+def _patch_sdk() -> None:
+    global _PATCHED
+    if _PATCHED:
+        return
+
+    original_parse_message = _mp.parse_message
+
+    def patched_parse_message(data):  # type: ignore[no-untyped-def]
+        try:
+            return original_parse_message(data)
+        except Exception:
+            logger.debug("Skipping unknown SDK message type: %s", data.get("type", "?"))
+            return None
+
+    _mp.parse_message = patched_parse_message
+    _sdk_client.parse_message = patched_parse_message
+
+    original_connect = _transport.SubprocessCLITransport.connect
+    original_read_messages_impl = _transport.SubprocessCLITransport._read_messages_impl
+
+    async def patched_connect(self):  # type: ignore[no-untyped-def]
+        orig_debug_stderr = self._options.debug_stderr
+        self._options.debug_stderr = subprocess.PIPE
+        had_debug_flag = "debug-to-stderr" in self._options.extra_args
+        if not had_debug_flag:
+            self._options.extra_args["debug-to-stderr"] = None
+
+        try:
+            await original_connect(self)
+        finally:
+            self._options.debug_stderr = orig_debug_stderr
+            if not had_debug_flag:
+                self._options.extra_args.pop("debug-to-stderr", None)
+
+    async def patched_read_messages_impl(self):  # type: ignore[no-untyped-def]
+        try:
+            async for message in original_read_messages_impl(self):
+                yield message
+        except _ProcessError as exc:
+            stderr_text = ""
+            if self._process and self._process.stderr:
+                try:
+                    raw = await self._process.stderr.receive()
+                    stderr_text = raw.decode("utf-8", errors="replace").strip()
+                except Exception:
+                    pass
+            if stderr_text:
+                logger.error("Claude Code CLI stderr:\n%s", stderr_text)
+                raise _ProcessError(
+                    f"{exc} - stderr: {stderr_text}",
+                    exit_code=exc.exit_code,
+                    stderr=stderr_text,
+                ) from exc
+            raise
+
+    _transport.SubprocessCLITransport.connect = patched_connect  # type: ignore[assignment]
+    _transport.SubprocessCLITransport._read_messages_impl = patched_read_messages_impl
+    _PATCHED = True
+
+
+def _additional_directories(config: AuditConfig, cwd: str) -> list[str]:
+    resolved_cwd = os.path.realpath(cwd)
+    dirs: list[str] = []
+    for candidate in [config.output_dir]:
+        resolved = os.path.realpath(candidate)
+        if resolved != resolved_cwd and os.path.isdir(resolved) and resolved not in dirs:
+            dirs.append(resolved)
+    return dirs
+
+
+class ClaudeCodeBackend:
+    async def run(
+        self,
+        prompt: str,
+        config: AuditConfig,
+        cwd: str,
+        allowed_tools: list[str] | None = None,
+        max_turns: int = 30,
+        model: str | None = None,
+        effort: str | None = None,
+        log_file: str | None = None,
+    ) -> str:
+        _patch_sdk()
+
+        tools = allowed_tools or DEFAULT_TOOLS
+        add_dirs = _additional_directories(config, cwd)
+
+        extra_args: dict[str, str | None] = {
+            "setting-sources": "",
+            "disable-slash-commands": None,
+        }
+        if effort:
+            extra_args["effort"] = effort
+
+        options = ClaudeCodeOptions(
+            allowed_tools=tools,
+            permission_mode="bypassPermissions",
+            max_turns=max_turns,
+            model=model or config.model,
+            cwd=cwd,
+            add_dirs=add_dirs,
+            extra_args=extra_args,
+        )
+
+        log_fh = None
+        if log_file:
+            os.makedirs(os.path.dirname(log_file), exist_ok=True)
+            log_fh = open(log_file, "a")  # noqa: SIM115
+            if log_fh.tell() > 0:
+                log_fh.write("\n--- new agent invocation ---\n\n")
+                log_fh.flush()
+
+        last_exc: Exception | None = None
+        try:
+            for attempt in range(AGENT_MAX_RETRIES):
+                try:
+                    text_parts: list[str] = []
+                    if log_fh and attempt > 0:
+                        log_fh.write(f"\n--- retry attempt {attempt + 1} ---\n\n")
+                        log_fh.flush()
+                    async for message in query(prompt=prompt, options=options):
+                        if message is None:
+                            continue
+                        if hasattr(message, "content"):
+                            for block in message.content:
+                                if hasattr(block, "text"):
+                                    text_parts.append(block.text)
+                                    if log_fh:
+                                        log_fh.write(block.text)
+                                        log_fh.write("\n")
+                                        log_fh.flush()
+                    return "\n".join(text_parts)
+                except Exception as exc:
+                    last_exc = exc
+                    if attempt < AGENT_MAX_RETRIES - 1:
+                        delay = AGENT_RETRY_BASE_DELAY * (2 ** attempt)
+                        logger.warning(
+                            "Agent call failed (attempt %d/%d), retrying in %ds: %s",
+                            attempt + 1, AGENT_MAX_RETRIES, delay, exc,
+                        )
+                        await asyncio.sleep(delay)
+                    else:
+                        logger.error("Agent call failed after %d attempts: %s", AGENT_MAX_RETRIES, exc)
+
+            raise last_exc  # type: ignore[misc]
+        finally:
+            if log_fh and not log_fh.closed:
+                log_fh.close()

--- a/code_auditor/agent_backends/codex.py
+++ b/code_auditor/agent_backends/codex.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from ..config import AuditConfig
+from ..logger import get_logger
+
+logger = get_logger("agent.codex")
+
+CODEX_MAX_RETRIES = 3
+CODEX_RETRY_BASE_DELAY = 10  # seconds
+
+
+class CodexTurnFailedError(RuntimeError):
+    pass
+
+
+class CodexBackend:
+    async def run(
+        self,
+        prompt: str,
+        config: AuditConfig,
+        cwd: str,
+        allowed_tools: list[str] | None = None,
+        max_turns: int = 30,
+        model: str | None = None,
+        effort: str | None = None,
+        log_file: str | None = None,
+    ) -> str:
+        if allowed_tools is not None:
+            logger.debug("Codex backend ignores Claude-style allowed_tools: %s", allowed_tools)
+
+        _prepare_local_sdk_path(config.codex_sdk_path)
+
+        try:
+            from codex_app_server import (  # type: ignore[import-not-found]
+                AppServerConfig,
+                AskForApproval,
+                AsyncCodex,
+                ReasoningEffort,
+                SandboxMode,
+                SandboxPolicy,
+                TextInput,
+            )
+        except ImportError as exc:
+            raise RuntimeError(
+                "Codex backend requires the Codex app-server Python SDK. "
+                "Install codex-app-server-sdk, or pass --codex-sdk-path pointing "
+                "to codex-main/sdk/python."
+            ) from exc
+
+        approval_policy = AskForApproval.model_validate(config.codex_approval_policy)
+        sandbox_mode = SandboxMode(config.codex_sandbox)
+        sandbox_policy = SandboxPolicy.model_validate(
+            _sandbox_policy_payload(config, cwd),
+        )
+        reasoning_effort = ReasoningEffort(effort) if effort else None
+
+        app_config = AppServerConfig(
+            codex_bin=config.codex_bin,
+            cwd=cwd,
+        )
+
+        last_exc: Exception | None = None
+        for attempt in range(CODEX_MAX_RETRIES):
+            try:
+                return await self._run_once(
+                    prompt=prompt,
+                    config=config,
+                    cwd=cwd,
+                    model=model,
+                    app_config=app_config,
+                    approval_policy=approval_policy,
+                    sandbox_mode=sandbox_mode,
+                    sandbox_policy=sandbox_policy,
+                    reasoning_effort=reasoning_effort,
+                    text_input_cls=TextInput,
+                    async_codex_cls=AsyncCodex,
+                    log_file=log_file,
+                )
+            except Exception as exc:
+                last_exc = exc
+                if attempt < CODEX_MAX_RETRIES - 1 and _is_retryable_codex_error(exc):
+                    delay = CODEX_RETRY_BASE_DELAY * (2 ** attempt)
+                    logger.warning(
+                        "Codex agent call failed (attempt %d/%d), retrying in %ds: %s",
+                        attempt + 1, CODEX_MAX_RETRIES, delay, exc,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                logger.error("Codex agent call failed after %d attempt(s): %s", attempt + 1, exc)
+                raise
+
+        raise last_exc  # type: ignore[misc]
+
+    async def _run_once(
+        self,
+        *,
+        prompt: str,
+        config: AuditConfig,
+        cwd: str,
+        model: str | None,
+        app_config: object,
+        approval_policy: object,
+        sandbox_mode: object,
+        sandbox_policy: object,
+        reasoning_effort: object | None,
+        text_input_cls: type,
+        async_codex_cls: type,
+        log_file: str | None,
+    ) -> str:
+        text_parts: list[str] = []
+        completed = False
+        completed_status: str | None = None
+        completed_error: str | None = None
+
+        async with async_codex_cls(config=app_config) as codex:
+            thread = await codex.thread_start(
+                approval_policy=approval_policy,
+                cwd=cwd,
+                model=model or config.model,
+                sandbox=sandbox_mode,
+            )
+            turn = await thread.turn(
+                text_input_cls(prompt),
+                approval_policy=approval_policy,
+                cwd=cwd,
+                effort=reasoning_effort,
+                model=model or config.model,
+                sandbox_policy=sandbox_policy,
+            )
+
+            log_fh = _open_log(log_file)
+            try:
+                async for event in turn.stream():
+                    text_parts.extend(_text_from_event(event))
+                    _write_event_log(log_fh, event)
+                    state = _turn_completed_state(event)
+                    if state is not None:
+                        completed = True
+                        completed_status, completed_error = state
+            finally:
+                if log_fh and not log_fh.closed:
+                    log_fh.close()
+
+        if not completed:
+            raise CodexTurnFailedError("Codex turn stream ended before turn/completed.")
+        if completed_status != "completed":
+            detail = f": {completed_error}" if completed_error else ""
+            raise CodexTurnFailedError(f"Codex turn ended with status {completed_status}{detail}")
+
+        return "".join(text_parts)
+
+
+def _prepare_local_sdk_path(sdk_path: str | None) -> None:
+    if not sdk_path:
+        return
+
+    root = Path(sdk_path)
+    src = root / "src"
+    candidate = src if (src / "codex_app_server").is_dir() else root
+    candidate_text = str(candidate)
+    if candidate_text not in sys.path:
+        sys.path.insert(0, candidate_text)
+
+
+def _sandbox_policy_payload(config: AuditConfig, cwd: str) -> dict[str, Any]:
+    if config.codex_sandbox == "danger-full-access":
+        return {"type": "dangerFullAccess"}
+
+    if config.codex_sandbox == "read-only":
+        return {
+            "type": "readOnly",
+            "access": {"type": "fullAccess"},
+            "networkAccess": config.codex_network_access,
+        }
+
+    roots = _dedupe_paths([
+        cwd,
+        config.output_dir,
+        *config.codex_extra_writable_roots,
+    ])
+    return {
+        "type": "workspaceWrite",
+        "networkAccess": config.codex_network_access,
+        "readOnlyAccess": {"type": "fullAccess"},
+        "writableRoots": roots,
+    }
+
+
+def _dedupe_paths(paths: list[str]) -> list[str]:
+    result: list[str] = []
+    for path in paths:
+        resolved = os.path.realpath(path)
+        if resolved not in result:
+            result.append(resolved)
+    return result
+
+
+def _open_log(log_file: str | None):
+    if not log_file:
+        return None
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    fh = open(log_file, "a")  # noqa: SIM115
+    if fh.tell() > 0:
+        fh.write("\n--- new agent invocation ---\n\n")
+        fh.flush()
+    return fh
+
+
+def _text_from_event(event: object) -> list[str]:
+    if getattr(event, "method", "") != "item/agentMessage/delta":
+        return []
+    payload = getattr(event, "payload", None)
+    delta = getattr(payload, "delta", "")
+    return [delta] if isinstance(delta, str) and delta else []
+
+
+def _write_event_log(log_fh, event: object) -> None:
+    if not log_fh:
+        return
+
+    method = getattr(event, "method", "unknown")
+    payload = getattr(event, "payload", None)
+
+    if method == "item/agentMessage/delta":
+        delta = getattr(payload, "delta", "")
+        if delta:
+            log_fh.write(delta)
+            log_fh.flush()
+        return
+
+    if method in {"turn/started", "turn/completed", "error"}:
+        log_fh.write(f"\n[{method}] {_payload_summary(payload)}\n")
+        log_fh.flush()
+
+
+def _payload_summary(payload: object) -> str:
+    if payload is None:
+        return ""
+    if hasattr(payload, "model_dump_json"):
+        try:
+            return payload.model_dump_json()
+        except Exception:
+            pass
+    return str(payload)
+
+
+def _turn_completed_state(event: object) -> tuple[str | None, str | None] | None:
+    if getattr(event, "method", "") != "turn/completed":
+        return None
+
+    payload = getattr(event, "payload", None)
+    turn = getattr(payload, "turn", None)
+    raw_status = getattr(turn, "status", None)
+    status = _enum_or_string_value(raw_status)
+    error = getattr(turn, "error", None)
+    return status, _payload_summary(error) if error is not None else None
+
+
+def _enum_or_string_value(value: object) -> str | None:
+    if value is None:
+        return None
+    enum_value = getattr(value, "value", None)
+    if isinstance(enum_value, str):
+        return enum_value
+    return str(value)
+
+
+def _is_retryable_codex_error(exc: Exception) -> bool:
+    text = str(exc).lower()
+    retryable_fragments = [
+        "stream disconnected",
+        "tls handshake",
+        "network error",
+        "error sending request",
+        "timeout",
+        "temporarily",
+        "connection",
+        "ended before turn/completed",
+    ]
+    return any(fragment in text for fragment in retryable_fragments)

--- a/code_auditor/config.py
+++ b/code_auditor/config.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6"
+DEFAULT_CODEX_MODEL = "gpt-5.4"
+
 DEFAULT_THREAT_MODEL = (
     "Network attacker with full control over protocol messages. "
     "The attacker can send arbitrary bytes, malformed messages, "
@@ -19,8 +22,15 @@ class AuditConfig:
     skip_stages: list[int] = field(default_factory=list)
     resume: bool = True
     log_level: str = "INFO"
-    model: str = "claude-sonnet-4-6"
+    model: str = DEFAULT_CLAUDE_MODEL
     target_au_count: int = 10
+    agent_backend: str = "claude-code"
+    codex_bin: str | None = None
+    codex_sdk_path: str | None = None
+    codex_sandbox: str = "workspace-write"
+    codex_approval_policy: str = "never"
+    codex_network_access: bool = False
+    codex_extra_writable_roots: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/code_auditor/stages/stage5.py
+++ b/code_auditor/stages/stage5.py
@@ -36,6 +36,10 @@ def _read_vuln_id(file_path: str) -> str | None:
         return None
 
 
+def _stage_model(config: AuditConfig) -> str | None:
+    return _DEFAULT_MODEL if config.agent_backend == "claude-code" else None
+
+
 async def _run_reproduce(
     vuln_file_path: str,
     config: AuditConfig,
@@ -80,7 +84,7 @@ async def _run_reproduce(
             config,
             cwd=config.target,
             max_turns=_MAX_TURNS,
-            model=_DEFAULT_MODEL,
+            model=_stage_model(config),
             effort=_DEFAULT_EFFORT,
             log_file=log_file,
         )

--- a/code_auditor/stages/stage6.py
+++ b/code_auditor/stages/stage6.py
@@ -48,6 +48,10 @@ def _filter_reproduced(stage5_reports: list[str]) -> list[str]:
     return [r for r in stage5_reports if not Path(r).parent.name.endswith("_fp")]
 
 
+def _stage_model(config: AuditConfig) -> str | None:
+    return _DEFAULT_MODEL if config.agent_backend == "claude-code" else None
+
+
 async def _run_disclosure(
     report_path: str,
     config: AuditConfig,
@@ -106,7 +110,7 @@ async def _run_disclosure(
             config,
             cwd=config.target,
             max_turns=_MAX_TURNS,
-            model=_DEFAULT_MODEL,
+            model=_stage_model(config),
             effort=_DEFAULT_EFFORT,
             log_file=log_file,
         )

--- a/code_auditor/tests/test_agent_backends.py
+++ b/code_auditor/tests/test_agent_backends.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+from enum import Enum
+from types import SimpleNamespace
+
+import pytest
+
+from code_auditor.agent import _get_backend
+from code_auditor.agent_backends.codex import (
+    CodexTurnFailedError,
+    _is_retryable_codex_error,
+    _sandbox_policy_payload,
+    _turn_completed_state,
+)
+from code_auditor.config import AuditConfig
+
+
+def test_unknown_agent_backend_rejected():
+    config = AuditConfig(
+        target="/tmp/target",
+        output_dir="/tmp/output",
+        agent_backend="unknown",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported agent backend"):
+        _get_backend(config)
+
+
+def test_codex_workspace_write_policy_includes_target_output_and_extra_roots():
+    config = AuditConfig(
+        target="/tmp/target",
+        output_dir="/tmp/output",
+        agent_backend="codex",
+        codex_extra_writable_roots=["/tmp/output", "/tmp/extra"],
+    )
+
+    policy = _sandbox_policy_payload(config, "/tmp/target")
+
+    assert policy["type"] == "workspaceWrite"
+    assert policy["networkAccess"] is False
+    assert policy["writableRoots"] == [
+        os.path.realpath("/tmp/target"),
+        os.path.realpath("/tmp/output"),
+        os.path.realpath("/tmp/extra"),
+    ]
+
+
+def test_codex_danger_full_access_policy():
+    config = AuditConfig(
+        target="/tmp/target",
+        output_dir="/tmp/output",
+        agent_backend="codex",
+        codex_sandbox="danger-full-access",
+    )
+
+    assert _sandbox_policy_payload(config, "/tmp/target") == {"type": "dangerFullAccess"}
+
+
+def test_codex_turn_completed_state_reads_success_status():
+    class Status(Enum):
+        completed = "completed"
+
+    event = SimpleNamespace(
+        method="turn/completed",
+        payload=SimpleNamespace(turn=SimpleNamespace(status=Status.completed, error=None)),
+    )
+
+    assert _turn_completed_state(event) == ("completed", None)
+
+
+def test_codex_turn_completed_state_reads_failed_error():
+    event = SimpleNamespace(
+        method="turn/completed",
+        payload=SimpleNamespace(
+            turn=SimpleNamespace(
+                status="failed",
+                error=SimpleNamespace(message="stream disconnected before completion"),
+            ),
+        ),
+    )
+
+    status, error = _turn_completed_state(event)
+
+    assert status == "failed"
+    assert "stream disconnected" in error
+
+
+def test_codex_network_turn_failure_is_retryable():
+    exc = CodexTurnFailedError(
+        "Codex turn ended with status failed: stream disconnected before completion: "
+        "error sending request for url"
+    )
+
+    assert _is_retryable_codex_error(exc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,19 @@ build-backend = "hatchling.build"
 [project]
 name = "code-auditor"
 version = "0.1.0"
-description = "Multi-stage code auditing agent application using Claude Code SDK"
+description = "Multi-stage code auditing agent application using Claude Code or Codex agent backends"
 requires-python = ">=3.12"
 dependencies = [
     "claude-code-sdk>=0.0.25",
+]
+
+[project.optional-dependencies]
+codex = [
+    "codex-app-server-sdk @ git+https://github.com/openai/codex.git@main#subdirectory=sdk/python",
+]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=1.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
  ## Summary

  - Add a pluggable agent backend layer and move the existing Claude Code execution logic
  into a dedicated backend adapter.
  - Add an experimental Codex app-server backend with local SDK path support, sandbox
  policy configuration, transient retry handling, and failed-turn detection.
  - Extend CLI/config/docs to support selecting `claude-code` or `codex` backends while
  keeping Claude Code as the default.
  - Keep Stage 5/6 Claude Opus override scoped to the Claude Code backend so Codex uses
  the configured Codex model.

  ## Testing

  - `.venv/bin/python -m pytest`
  - `.venv/bin/python -m compileall code_auditor`
  - `git diff --check`

