### PR TITLE
Fix backend model and Claude settings selection

### DIFF
--- a/code_auditor/agent.py
+++ b/code_auditor/agent.py
@@ -157,9 +157,8 @@ async def _run_claude_agent(
     add_dirs = _additional_directories(config, cwd)
 
     extra_args: dict[str, str | None] = {
-        # Run sub-agents like a clean Claude Code install: no user/project
-        # settings, no plugins, no hooks, no CLAUDE.md, no slash commands.
-        "setting-sources": "",
+        # Keep Claude Code settings sources enabled so provider/auth
+        # configuration from ~/.claude/settings.json is honored.
         "disable-slash-commands": None,
     }
     if effort:

--- a/code_auditor/config.py
+++ b/code_auditor/config.py
@@ -9,6 +9,7 @@ DEFAULT_BACKEND: AgentBackend = "claude"
 DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6"
 DEFAULT_CLAUDE_POC_MODEL = "claude-opus-4-6"
 DEFAULT_CODEX_MODEL = "gpt-5.4"
+DEFAULT_CODEX_POC_MODEL = "gpt-5.5"
 
 DEFAULT_THREAT_MODEL = (
     "Network attacker with full control over protocol messages. "
@@ -30,6 +31,14 @@ class AuditConfig:
     backend: AgentBackend = DEFAULT_BACKEND
     model: str | None = None
     target_au_count: int = 10
+
+
+def select_poc_model(config: AuditConfig) -> str:
+    if config.model:
+        return config.model
+    if config.backend == "claude":
+        return DEFAULT_CLAUDE_POC_MODEL
+    return DEFAULT_CODEX_POC_MODEL
 
 
 @dataclass

--- a/code_auditor/stages/stage5.py
+++ b/code_auditor/stages/stage5.py
@@ -7,7 +7,7 @@ import shutil
 
 from ..agent import run_agent
 from ..checkpoint import CheckpointManager
-from ..config import DEFAULT_CLAUDE_POC_MODEL, AuditConfig
+from ..config import AuditConfig, select_poc_model
 from ..logger import get_logger
 from ..prompts import load_prompt
 from ..utils import run_parallel_limited
@@ -79,7 +79,7 @@ async def _run_reproduce(
             config,
             cwd=config.target,
             max_turns=_MAX_TURNS,
-            model=DEFAULT_CLAUDE_POC_MODEL if config.backend == "claude" else config.model,
+            model=select_poc_model(config),
             effort=_DEFAULT_EFFORT,
             log_file=log_file,
         )

--- a/code_auditor/stages/stage6.py
+++ b/code_auditor/stages/stage6.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from ..agent import run_agent
 from ..checkpoint import CheckpointManager
-from ..config import DEFAULT_CLAUDE_POC_MODEL, AuditConfig
+from ..config import AuditConfig, select_poc_model
 from ..logger import get_logger
 from ..prompts import load_prompt
 from ..utils import run_parallel_limited
@@ -105,7 +105,7 @@ async def _run_disclosure(
             config,
             cwd=config.target,
             max_turns=_MAX_TURNS,
-            model=DEFAULT_CLAUDE_POC_MODEL if config.backend == "claude" else config.model,
+            model=select_poc_model(config),
             effort=_DEFAULT_EFFORT,
             log_file=log_file,
         )

--- a/code_auditor/tests/test_backend_selection.py
+++ b/code_auditor/tests/test_backend_selection.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from code_auditor import agent
 from code_auditor.__main__ import _build_parser
-from code_auditor.config import DEFAULT_BACKEND, AuditConfig
+from code_auditor.config import (
+    DEFAULT_BACKEND,
+    DEFAULT_CLAUDE_POC_MODEL,
+    DEFAULT_CODEX_POC_MODEL,
+    AgentBackend,
+    AuditConfig,
+    select_poc_model,
+)
 
 
 def test_cli_backend_defaults_to_claude() -> None:
@@ -28,6 +37,30 @@ def test_cli_accepts_codex_backend_and_model_override() -> None:
     assert args.model == "gpt-5.4"
 
 
+@pytest.mark.parametrize(
+    ("backend", "config_model", "expected_model"),
+    [
+        ("claude", None, DEFAULT_CLAUDE_POC_MODEL),
+        ("codex", None, DEFAULT_CODEX_POC_MODEL),
+        ("claude", "custom-global-model", "custom-global-model"),
+        ("codex", "custom-global-model", "custom-global-model"),
+    ],
+)
+def test_select_poc_model_prefers_global_model_override(
+    backend: AgentBackend,
+    config_model: str | None,
+    expected_model: str,
+) -> None:
+    config = AuditConfig(
+        target="/tmp/project",
+        output_dir="/tmp/output",
+        backend=backend,
+        model=config_model,
+    )
+
+    assert select_poc_model(config) == expected_model
+
+
 def test_resolve_codex_bin_uses_default_path(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
     codex_bin = tmp_path / "codex"
     codex_bin.write_text("#!/bin/sh\n")
@@ -45,16 +78,43 @@ def test_resolve_codex_bin_rejects_missing_default(monkeypatch: pytest.MonkeyPat
         agent._resolve_codex_bin()
 
 
-async def test_run_agent_dispatches_to_codex_backend(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_codex_agent(*_args, **_kwargs) -> str:  # type: ignore[no-untyped-def]
-        return "codex-result"
+def test_run_agent_dispatches_to_codex_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run_case() -> None:
+        async def fake_codex_agent(*_args, **_kwargs) -> str:  # type: ignore[no-untyped-def]
+            return "codex-result"
 
-    async def fake_claude_agent(*_args, **_kwargs) -> str:  # type: ignore[no-untyped-def]
-        raise AssertionError("Claude backend should not be called")
+        async def fake_claude_agent(*_args, **_kwargs) -> str:  # type: ignore[no-untyped-def]
+            raise AssertionError("Claude backend should not be called")
 
-    monkeypatch.setattr(agent, "_run_codex_agent", fake_codex_agent)
-    monkeypatch.setattr(agent, "_run_claude_agent", fake_claude_agent)
+        monkeypatch.setattr(agent, "_run_codex_agent", fake_codex_agent)
+        monkeypatch.setattr(agent, "_run_claude_agent", fake_claude_agent)
 
-    config = AuditConfig(target="/tmp/project", output_dir="/tmp/output", backend="codex")
+        config = AuditConfig(target="/tmp/project", output_dir="/tmp/output", backend="codex")
 
-    assert await agent.run_agent("prompt", config, cwd="/tmp/project") == "codex-result"
+        assert await agent.run_agent("prompt", config, cwd="/tmp/project") == "codex-result"
+
+    asyncio.run(run_case())
+
+
+def test_claude_backend_keeps_claude_code_settings_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run_case() -> None:
+        captured: dict[str, dict[str, str | None]] = {}
+
+        class FakeClaudeCodeOptions:
+            def __init__(self, **kwargs) -> None:  # type: ignore[no-untyped-def]
+                self.__dict__.update(kwargs)
+
+        async def fake_query(*, prompt: str, options: FakeClaudeCodeOptions):  # type: ignore[no-untyped-def]
+            captured["extra_args"] = options.extra_args
+            if False:
+                yield None
+
+        monkeypatch.setattr(agent, "_load_claude_sdk", lambda: (FakeClaudeCodeOptions, fake_query))
+
+        config = AuditConfig(target="/tmp/project", output_dir="/tmp/output", backend="claude")
+
+        await agent.run_agent("prompt", config, cwd="/tmp/project")
+
+        assert "setting-sources" not in captured["extra_args"]
+
+    asyncio.run(run_case())


### PR DESCRIPTION
## Summary
- Respect Claude Code settings sources so MiMo provider/auth configuration in ~/.claude/settings.json is honored.
- Add Codex PoC/disclosure default model selection with gpt-5.5 for stages 5 and 6.
- Let a global --model override stage-specific defaults and cover backend/model selection with tests.

## Test Plan
- source ~/miniconda3/etc/profile.d/conda.sh && conda activate audit && python -m pytest code_auditor/tests
- source ~/miniconda3/etc/profile.d/conda.sh && conda activate audit && python -m compileall code_auditor