### PR TITLE
Add read-only wiki knowledge base support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ code-auditor --target /path/to/project [--output-dir DIR] [--max-parallel 2] [--
 #   --target           Root directory of project to audit
 # Optional args
 #   --output-dir       Defaults to {target}/audit-output
+#   --wiki            LLM wiki knowledge base directory (treated as read-only)
 #   --max-parallel     Concurrent agents (default 2)
 #   --resume           Resume from checkpoint markers
 #   --threat-model     Override default threat model text

--- a/README.md
+++ b/README.md
@@ -85,11 +85,37 @@ code-auditor --target /path/to/project [options]
 |------|-------------|
 | `--target` | **Required.** Root directory of the project to audit. |
 | `--output-dir` | Output directory (default: `{target}/audit-output`). |
+| `--wiki` | LLM wiki knowledge base directory. CodeAuditor treats it as read-only and gives agents stage-specific wiki search guidance. |
 | `--max-parallel` | Max concurrent agents (default: `1`). |
 | `--backend` | Agent backend: `claude` or `codex` (default: `claude`). |
 | `--model` | Backend model override. Claude defaults to `claude-sonnet-4-6`; Codex uses the local Codex config default unless specified. |
 | `--target-au-count` | Target number of analysis units for Stage 2 (default: `10`). |
 | `--log-level` | `DEBUG` \| `INFO` \| `WARNING` \| `ERROR` (default: `INFO`). |
+
+### Wiki knowledge base
+
+`--wiki /path/to/wiki` lets CodeAuditor use an existing LLM wiki knowledge base during the audit. CodeAuditor treats the wiki as read-only and instructs agents not to create, edit, or update wiki files. Enforce filesystem permissions externally if write prevention is required.
+
+Recommended structure:
+
+```text
+wiki/
+|-- index.md
+|-- overview.md
+|-- attack-surface.md
+|-- auditing-guide.md
+|-- exploit-patterns.md
+|-- reproduction-workflow.md
+|-- vulnerability-timeline.md
+|-- entities/
+|   `-- <component>.md
+|-- concepts/
+|   `-- <vulnerability-class>.md
+`-- sources/
+    `-- <cve-or-case-study>.md
+```
+
+`index.md` is recommended as the navigation entry point. Partial wikis are supported; stages skip absent files and use the pages that exist.
 
 Runs resume from checkpoint markers automatically — delete the output directory (or its `.markers/` subdirectory) to start a fresh audit.
 
@@ -99,6 +125,7 @@ Runs resume from checkpoint markers automatically — delete the output director
 code-auditor \
   --target ~/projects/libfoo \
   --output-dir ~/audits/libfoo \
+  --wiki ~/knowledge/libfoo-wiki \
   --max-parallel 4 \
   --log-level DEBUG
 ```

--- a/code_auditor/__main__.py
+++ b/code_auditor/__main__.py
@@ -19,6 +19,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--target", required=True, help="Root directory of the project to audit")
     parser.add_argument("--output-dir", help="Output directory (default: {target}/audit-output)")
+    parser.add_argument("--wiki", help="Read-only LLM wiki knowledge base directory")
     parser.add_argument("--max-parallel", type=int, default=1, help="Maximum concurrent agents (default: 1)")
     parser.add_argument(
         "--backend",
@@ -40,6 +41,20 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _resolve_wiki_path(path: str | None) -> str | None:
+    if not path:
+        return None
+
+    resolved = os.path.realpath(path)
+    if not os.path.exists(resolved):
+        print(f"Error: Wiki directory not found: {resolved}", file=sys.stderr)
+        sys.exit(1)
+    if not os.path.isdir(resolved):
+        print(f"Error: Wiki path is not a directory: {resolved}", file=sys.stderr)
+        sys.exit(1)
+    return resolved
+
+
 def main() -> None:
     parser = _build_parser()
     args = parser.parse_args()
@@ -50,12 +65,14 @@ def main() -> None:
         sys.exit(1)
 
     output_dir = os.path.realpath(args.output_dir or os.path.join(target, "audit-output"))
+    wiki_path = _resolve_wiki_path(args.wiki)
 
     skip_stages = [5, 6] if args.audit_only else []
 
     config = AuditConfig(
         target=target,
         output_dir=output_dir,
+        wiki_path=wiki_path,
         max_parallel=args.max_parallel,
         resume=True,
         log_level=args.log_level.upper(),

--- a/code_auditor/agent.py
+++ b/code_auditor/agent.py
@@ -113,7 +113,9 @@ DEFAULT_TOOLS = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"]
 def _additional_directories(config: AuditConfig, cwd: str) -> list[str]:
     resolved_cwd = os.path.realpath(cwd)
     dirs: list[str] = []
-    for candidate in [config.output_dir]:
+    for candidate in [config.output_dir, config.wiki_path]:
+        if not candidate:
+            continue
         resolved = os.path.realpath(candidate)
         if resolved != resolved_cwd and os.path.isdir(resolved) and resolved not in dirs:
             dirs.append(resolved)

--- a/code_auditor/config.py
+++ b/code_auditor/config.py
@@ -21,6 +21,7 @@ DEFAULT_THREAT_MODEL = (
 class AuditConfig:
     target: str
     output_dir: str
+    wiki_path: str | None = None
     max_parallel: int = 1
     threat_model: str = DEFAULT_THREAT_MODEL
     scope: str = ""

--- a/code_auditor/stages/stage1.py
+++ b/code_auditor/stages/stage1.py
@@ -11,6 +11,7 @@ from ..config import AuditConfig
 from ..logger import get_logger
 from ..prompts import load_prompt
 from ..validation.stage1 import validate_stage1_file
+from ..wiki import build_wiki_context
 
 logger = get_logger("stage1")
 _TASK_KEY = "stage1"
@@ -51,6 +52,7 @@ async def run_stage1(
         "today": today,
         "start_date": start_date,
         "user_instructions": config.scope or "No additional scope constraints.",
+        "wiki_context": build_wiki_context(config, stage=1),
     })
 
     passed, _ = await run_with_validation(

--- a/code_auditor/stages/stage2.py
+++ b/code_auditor/stages/stage2.py
@@ -10,6 +10,7 @@ from ..parsing.stage2 import parse_au_files, parse_auditing_focus
 from ..prompts import load_prompt
 from ..utils import format_validation_issues
 from ..validation.stage2 import validate_stage2_dir
+from ..wiki import build_wiki_context
 
 logger = get_logger("stage2")
 _TASK_KEY = "stage2"
@@ -73,6 +74,7 @@ async def run_stage2(
         "scope_modules": scope_modules or "No scope information available.",
         "historical_hot_spots": hot_spots or "No historical data available.",
         "target_au_count": str(config.target_au_count),
+        "wiki_context": build_wiki_context(config, stage=2),
     })
 
     await run_agent(prompt, config, cwd=config.target, max_turns=200, log_file=log_file)

--- a/code_auditor/stages/stage3.py
+++ b/code_auditor/stages/stage3.py
@@ -10,6 +10,7 @@ from ..logger import get_logger
 from ..prompts import load_prompt
 from ..utils import format_validation_issues, list_matching_files, run_parallel_limited
 from ..validation.stage3 import validate_stage3_file
+from ..wiki import build_wiki_context
 
 logger = get_logger("stage3")
 
@@ -45,6 +46,7 @@ async def _run_unit(
         "finding_prefix": unit.id,
         "auditing_focus_path": auditing_focus_path,
         "vuln_criteria_path": vuln_criteria_path,
+        "wiki_context": build_wiki_context(config, stage=3),
     })
 
     await run_agent(prompt, config, cwd=config.target, max_turns=200, log_file=log_file)

--- a/code_auditor/stages/stage4.py
+++ b/code_auditor/stages/stage4.py
@@ -16,6 +16,7 @@ from ..utils import (
     run_parallel_limited,
 )
 from ..validation.stage4 import validate_stage4_file
+from ..wiki import build_wiki_context
 
 logger = get_logger("stage4")
 
@@ -102,6 +103,7 @@ async def _run_finding(
         "finding_file_path": stage3_file_path,
         "output_path": pending_path,
         "vuln_criteria_path": vuln_criteria_path,
+        "wiki_context": build_wiki_context(config, stage=4),
     })
 
     await run_agent(prompt, config, cwd=config.target, max_turns=100, log_file=log_file)

--- a/code_auditor/stages/stage5.py
+++ b/code_auditor/stages/stage5.py
@@ -11,6 +11,7 @@ from ..config import DEFAULT_CLAUDE_POC_MODEL, AuditConfig
 from ..logger import get_logger
 from ..prompts import load_prompt
 from ..utils import run_parallel_limited
+from ..wiki import build_wiki_context
 
 logger = get_logger("stage5")
 
@@ -68,6 +69,7 @@ async def _run_reproduce(
         "target_path": config.target,
         "poc_dir": poc_dir,
         "finding_id": vuln_id,
+        "wiki_context": build_wiki_context(config, stage=5),
     })
 
     log_file = os.path.join(poc_dir, "agent.log")

--- a/code_auditor/stages/stage6.py
+++ b/code_auditor/stages/stage6.py
@@ -10,6 +10,7 @@ from ..config import DEFAULT_CLAUDE_POC_MODEL, AuditConfig
 from ..logger import get_logger
 from ..prompts import load_prompt
 from ..utils import run_parallel_limited
+from ..wiki import build_wiki_context
 
 logger = get_logger("stage6")
 
@@ -94,6 +95,7 @@ async def _run_disclosure(
         "target_path": config.target,
         "disclosure_dir": disclosure_dir,
         "vuln_id": vuln_id,
+        "wiki_context": build_wiki_context(config, stage=6),
     })
 
     log_file = os.path.join(stage6_vuln_dir, "agent.log")

--- a/code_auditor/tests/test_backend_selection.py
+++ b/code_auditor/tests/test_backend_selection.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import sys
+
 import pytest
 
+from code_auditor import __main__ as main_module
 from code_auditor import agent
 from code_auditor.__main__ import _build_parser
 from code_auditor.config import DEFAULT_BACKEND, AuditConfig
@@ -26,6 +29,93 @@ def test_cli_accepts_codex_backend_and_model_override() -> None:
 
     assert args.backend == "codex"
     assert args.model == "gpt-5.4"
+
+
+def test_cli_accepts_wiki_path() -> None:
+    args = _build_parser().parse_args([
+        "--target",
+        ".",
+        "--wiki",
+        "/tmp/wiki",
+    ])
+
+    assert args.wiki == "/tmp/wiki"
+
+
+def test_main_maps_wiki_path_to_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, AuditConfig] = {}
+    target = tmp_path / "target"
+    wiki = tmp_path / "wiki"
+    target.mkdir()
+    wiki.mkdir()
+
+    async def fake_run_audit(config: AuditConfig) -> None:
+        captured["config"] = config
+
+    monkeypatch.setattr(main_module, "run_audit", fake_run_audit)
+    monkeypatch.setattr(sys, "argv", [
+        "code-auditor",
+        "--target",
+        str(target),
+        "--wiki",
+        str(wiki),
+    ])
+
+    main_module.main()
+
+    assert captured["config"].wiki_path == str(wiki.resolve())
+
+
+def test_main_rejects_missing_wiki_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = tmp_path / "target"
+    missing_wiki = tmp_path / "missing-wiki"
+    target.mkdir()
+
+    monkeypatch.setattr(sys, "argv", [
+        "code-auditor",
+        "--target",
+        str(target),
+        "--wiki",
+        str(missing_wiki),
+    ])
+
+    with pytest.raises(SystemExit) as exc:
+        main_module.main()
+
+    assert exc.value.code == 1
+    assert f"Error: Wiki directory not found: {missing_wiki.resolve()}" in capsys.readouterr().err
+
+
+def test_main_rejects_wiki_file_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = tmp_path / "target"
+    wiki_file = tmp_path / "wiki.md"
+    target.mkdir()
+    wiki_file.write_text("# Not a directory\n")
+
+    monkeypatch.setattr(sys, "argv", [
+        "code-auditor",
+        "--target",
+        str(target),
+        "--wiki",
+        str(wiki_file),
+    ])
+
+    with pytest.raises(SystemExit) as exc:
+        main_module.main()
+
+    assert exc.value.code == 1
+    assert f"Error: Wiki path is not a directory: {wiki_file.resolve()}" in capsys.readouterr().err
 
 
 def test_resolve_codex_bin_uses_default_path(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:  # type: ignore[no-untyped-def]

--- a/code_auditor/tests/test_backend_selection.py
+++ b/code_auditor/tests/test_backend_selection.py
@@ -118,6 +118,39 @@ def test_main_rejects_wiki_file_path(
     assert f"Error: Wiki path is not a directory: {wiki_file.resolve()}" in capsys.readouterr().err
 
 
+def test_additional_directories_includes_existing_wiki_path(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    target = tmp_path / "target"
+    output = tmp_path / "output"
+    wiki = tmp_path / "wiki"
+    target.mkdir()
+    output.mkdir()
+    wiki.mkdir()
+    config = AuditConfig(
+        target=str(target),
+        output_dir=str(output),
+        wiki_path=str(wiki),
+    )
+
+    assert agent._additional_directories(config, str(target)) == [
+        str(output.resolve()),
+        str(wiki.resolve()),
+    ]
+
+
+def test_additional_directories_skips_wiki_when_it_is_cwd(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    target = tmp_path / "target"
+    output = tmp_path / "output"
+    target.mkdir()
+    output.mkdir()
+    config = AuditConfig(
+        target=str(target),
+        output_dir=str(output),
+        wiki_path=str(target),
+    )
+
+    assert agent._additional_directories(config, str(target)) == [str(output.resolve())]
+
+
 def test_resolve_codex_bin_uses_default_path(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
     codex_bin = tmp_path / "codex"
     codex_bin.write_text("#!/bin/sh\n")

--- a/code_auditor/tests/test_wiki_context.py
+++ b/code_auditor/tests/test_wiki_context.py
@@ -1,7 +1,36 @@
 from __future__ import annotations
 
+import pytest
+
 from code_auditor.config import AuditConfig
+from code_auditor.prompts import PROMPTS_DIR
 from code_auditor.wiki import build_wiki_context
+
+
+@pytest.mark.parametrize("prompt_name", [
+    "stage1.md",
+    "stage2.md",
+    "stage3.md",
+    "stage4.md",
+    "stage5.md",
+    "stage6.md",
+])
+def test_stage_prompt_templates_have_wiki_context_token(prompt_name: str) -> None:
+    text = (PROMPTS_DIR / prompt_name).read_text()
+
+    assert "## Wiki Knowledge Base" in text
+    assert "__WIKI_CONTEXT__" in text
+
+
+def test_stage3_wiki_context_does_not_parent_scope_or_task_sections() -> None:
+    text = (PROMPTS_DIR / "stage3.md").read_text()
+
+    scope_index = text.index("### Scope of Your Analysis")
+    task_index = text.index("Your task: discover security bugs and vulnerabilities")
+    wiki_index = text.index("## Wiki Knowledge Base")
+    output_index = text.index("## Output")
+
+    assert scope_index < task_index < wiki_index < output_index
 
 
 def test_build_wiki_context_returns_neutral_message_without_wiki() -> None:

--- a/code_auditor/tests/test_wiki_context.py
+++ b/code_auditor/tests/test_wiki_context.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from code_auditor.config import AuditConfig
+from code_auditor.wiki import build_wiki_context
+
+
+def test_build_wiki_context_returns_neutral_message_without_wiki() -> None:
+    config = AuditConfig(target="/tmp/project", output_dir="/tmp/output")
+
+    assert build_wiki_context(config, stage=3) == "No wiki knowledge base configured."
+
+
+def test_build_wiki_context_stage2_points_to_decomposition_locations(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    config = AuditConfig(target="/tmp/project", output_dir="/tmp/output", wiki_path=str(wiki))
+
+    context = build_wiki_context(config, stage=2)
+
+    assert f"Wiki root: `{wiki}`" in context
+    assert "read-only" in context
+    assert "index.md" in context
+    assert "attack-surface.md" in context
+    assert "auditing-guide.md" in context
+    assert "entities/" in context
+    assert "triage.json" in context
+
+
+def test_build_wiki_context_stage5_points_to_reproduction_locations(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    config = AuditConfig(target="/tmp/project", output_dir="/tmp/output", wiki_path=str(wiki))
+
+    context = build_wiki_context(config, stage=5)
+
+    assert "reproduction-workflow.md" in context
+    assert "expected evidence" in context
+    assert "entity" in context
+    assert "source" in context
+
+
+def test_build_wiki_context_unknown_stage_uses_generic_guidance(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    config = AuditConfig(target="/tmp/project", output_dir="/tmp/output", wiki_path=str(wiki))
+
+    context = build_wiki_context(config, stage=99)
+
+    assert "index.md" in context
+    assert "Use the wiki only as supporting audit knowledge." in context

--- a/code_auditor/wiki.py
+++ b/code_auditor/wiki.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from .config import AuditConfig
+
+NO_WIKI_CONTEXT = "No wiki knowledge base configured."
+
+_GENERIC_GUIDANCE = (
+    "Use the wiki only as supporting audit knowledge. Start with `index.md` if it exists, "
+    "then search root synthesis pages, `entities/`, `concepts/`, and `sources/` for pages "
+    "matching the current component, vulnerability class, or historical pattern."
+)
+
+_STAGE_GUIDANCE: dict[int, str] = {
+    1: (
+        "Stage 1 lookup: start with `index.md` and `overview.md` if present. Search "
+        "`vulnerability-timeline.md` and `sources/` for historical vulnerabilities, dates, "
+        "affected components, root causes, impacts, and attacker profiles. Use root synthesis "
+        "pages to supplement live research, and keep source attribution clear in the research record."
+    ),
+    2: (
+        "Stage 2 lookup: start with `index.md`, `attack-surface.md`, `auditing-guide.md`, "
+        "and `entities/`. Use entity pages to identify components that historically produce "
+        "impactful vulnerabilities. Use concept pages when they help explain why an area is "
+        "selected. Reflect relevant wiki knowledge in `triage.json` rationales and AU `focus` fields."
+    ),
+    3: (
+        "Stage 3 lookup: start from the AU files, then search `entities/` for matching components "
+        "or subsystem names. Search `concepts/` for vulnerability classes suggested by the code path. "
+        "Search `exploit-patterns.md` and matching `sources/` pages for historical bug shapes. "
+        "Use wiki pages as audit heuristics, not proof that this target is vulnerable."
+    ),
+    4: (
+        "Stage 4 lookup: search `concepts/` and relevant `sources/` pages to calibrate "
+        "false-positive checks, impact, and historical severity. Use `vulnerability-timeline.md` "
+        "for broad historical comparison when useful. Do not confirm a vulnerability solely because "
+        "a wiki page describes a similar historical issue; the source data-flow trace is authoritative."
+    ),
+    5: (
+        "Stage 5 lookup: start with `reproduction-workflow.md`. Search matching entity, concept, "
+        "and source pages for realistic trigger models, environment setup, expected evidence, and "
+        "reproduction pitfalls. Use the wiki to choose the lowest reproduction level that preserves "
+        "the vulnerable data flow."
+    ),
+    6: (
+        "Stage 6 lookup: search relevant entity, concept, source, and reproduction pages for clear "
+        "framing and maintainer-facing terminology. Use the wiki to improve report clarity, but keep "
+        "disclosure claims grounded in Stage 5 evidence and the target source. Do not include internal "
+        "wiki links or paths in disclosure artifacts unless they are explicitly useful for the recipient."
+    ),
+}
+
+
+def build_wiki_context(config: AuditConfig, stage: int) -> str:
+    if not config.wiki_path:
+        return NO_WIKI_CONTEXT
+
+    stage_guidance = _STAGE_GUIDANCE.get(stage, _GENERIC_GUIDANCE)
+    return "\n".join([
+        f"Wiki root: `{config.wiki_path}`",
+        "The wiki is read-only. Do not create, edit, move, or delete files in it.",
+        "If a referenced wiki file or directory is absent, skip it and continue with the available pages.",
+        "Prefer `index.md` for navigation when it exists.",
+        stage_guidance,
+    ])

--- a/docs/superpowers/plans/2026-04-30-wiki-knowledge-base.md
+++ b/docs/superpowers/plans/2026-04-30-wiki-knowledge-base.md
@@ -1,0 +1,733 @@
+# Wiki Knowledge Base Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only `--wiki` option that lets every audit stage search an existing LLM wiki knowledge base in stage-appropriate locations.
+
+**Architecture:** Store the resolved wiki directory on `AuditConfig`, expose it to backend agents as an additional readable directory, and inject stage-specific wiki lookup guidance into prompt templates through a small `code_auditor/wiki.py` helper. The helper guides agents to search the wiki instead of inlining full page contents, preserving context budget and keeping the wiki read-only.
+
+**Tech Stack:** Python 3.12, argparse, dataclasses, pytest, existing prompt substitution via `code_auditor/prompts.py`.
+
+---
+
+## File Structure
+
+- Modify `code_auditor/config.py`: add `wiki_path` to `AuditConfig`.
+- Modify `code_auditor/__main__.py`: add `--wiki`, validate it as an existing directory, pass the resolved path to `AuditConfig`.
+- Create `code_auditor/wiki.py`: build neutral or stage-specific wiki guidance text.
+- Modify `code_auditor/agent.py`: include `config.wiki_path` in additional readable directories for backend agents.
+- Modify `code_auditor/stages/stage1.py` through `code_auditor/stages/stage6.py`: pass `build_wiki_context(config, stage=N)` into prompt substitutions.
+- Modify `prompts/stage1.md` through `prompts/stage6.md`: add a `## Wiki Knowledge Base` section with `__WIKI_CONTEXT__`.
+- Modify `code_auditor/tests/test_backend_selection.py`: cover CLI/config and additional-directory behavior.
+- Create `code_auditor/tests/test_wiki_context.py`: cover the wiki helper and prompt template tokens.
+- Modify `README.md`: document `--wiki` and the recommended wiki layout.
+- Modify `CLAUDE.md`: add the quick-reference option.
+
+---
+
+### Task 1: CLI And Config
+
+**Files:**
+- Modify: `code_auditor/config.py`
+- Modify: `code_auditor/__main__.py`
+- Modify: `code_auditor/tests/test_backend_selection.py`
+
+- [ ] **Step 1: Write failing CLI/config tests**
+
+Add these tests to `code_auditor/tests/test_backend_selection.py`. Keep the existing tests and imports. Ensure `sys`, `pytest`, `main_module`, and `AuditConfig` are imported, because these tests use them.
+
+```python
+def test_cli_accepts_wiki_path() -> None:
+    args = _build_parser().parse_args([
+        "--target",
+        ".",
+        "--wiki",
+        "/tmp/wiki",
+    ])
+
+    assert args.wiki == "/tmp/wiki"
+
+
+def test_main_maps_wiki_path_to_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    captured: dict[str, AuditConfig] = {}
+    target = tmp_path / "target"
+    wiki = tmp_path / "wiki"
+    target.mkdir()
+    wiki.mkdir()
+
+    async def fake_run_audit(config: AuditConfig) -> None:
+        captured["config"] = config
+
+    monkeypatch.setattr(main_module, "run_audit", fake_run_audit)
+    monkeypatch.setattr(sys, "argv", [
+        "code-auditor",
+        "--target",
+        str(target),
+        "--wiki",
+        str(wiki),
+    ])
+
+    main_module.main()
+
+    assert captured["config"].wiki_path == str(wiki.resolve())
+
+
+def test_main_rejects_missing_wiki_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = tmp_path / "target"
+    missing_wiki = tmp_path / "missing-wiki"
+    target.mkdir()
+
+    monkeypatch.setattr(sys, "argv", [
+        "code-auditor",
+        "--target",
+        str(target),
+        "--wiki",
+        str(missing_wiki),
+    ])
+
+    with pytest.raises(SystemExit) as exc:
+        main_module.main()
+
+    assert exc.value.code == 1
+    assert f"Error: Wiki directory not found: {missing_wiki.resolve()}" in capsys.readouterr().err
+
+
+def test_main_rejects_wiki_file_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    target = tmp_path / "target"
+    wiki_file = tmp_path / "wiki.md"
+    target.mkdir()
+    wiki_file.write_text("# Not a directory\n")
+
+    monkeypatch.setattr(sys, "argv", [
+        "code-auditor",
+        "--target",
+        str(target),
+        "--wiki",
+        str(wiki_file),
+    ])
+
+    with pytest.raises(SystemExit) as exc:
+        main_module.main()
+
+    assert exc.value.code == 1
+    assert f"Error: Wiki path is not a directory: {wiki_file.resolve()}" in capsys.readouterr().err
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest code_auditor/tests/test_backend_selection.py::test_cli_accepts_wiki_path code_auditor/tests/test_backend_selection.py::test_main_maps_wiki_path_to_config code_auditor/tests/test_backend_selection.py::test_main_rejects_missing_wiki_path code_auditor/tests/test_backend_selection.py::test_main_rejects_wiki_file_path -v
+```
+
+Expected: at least one failure caused by missing `--wiki` support or missing `AuditConfig.wiki_path`.
+
+- [ ] **Step 3: Add config field**
+
+In `code_auditor/config.py`, add this field to `AuditConfig` after `output_dir`:
+
+```python
+    wiki_path: str | None = None
+```
+
+- [ ] **Step 4: Add CLI parsing and validation**
+
+In `code_auditor/__main__.py`, add this parser argument after `--output-dir`:
+
+```python
+    parser.add_argument("--wiki", help="Read-only LLM wiki knowledge base directory")
+```
+
+Add this helper near `_build_parser()`:
+
+```python
+def _resolve_wiki_path(path: str | None) -> str | None:
+    if not path:
+        return None
+
+    resolved = os.path.realpath(path)
+    if not os.path.exists(resolved):
+        print(f"Error: Wiki directory not found: {resolved}", file=sys.stderr)
+        sys.exit(1)
+    if not os.path.isdir(resolved):
+        print(f"Error: Wiki path is not a directory: {resolved}", file=sys.stderr)
+        sys.exit(1)
+    return resolved
+```
+
+In `main()`, resolve the wiki after `output_dir`:
+
+```python
+    wiki_path = _resolve_wiki_path(args.wiki)
+```
+
+Pass it to `AuditConfig`:
+
+```python
+        wiki_path=wiki_path,
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run:
+
+```bash
+pytest code_auditor/tests/test_backend_selection.py::test_cli_accepts_wiki_path code_auditor/tests/test_backend_selection.py::test_main_maps_wiki_path_to_config code_auditor/tests/test_backend_selection.py::test_main_rejects_missing_wiki_path code_auditor/tests/test_backend_selection.py::test_main_rejects_wiki_file_path -v
+```
+
+Expected: all four tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add code_auditor/config.py code_auditor/__main__.py code_auditor/tests/test_backend_selection.py
+git commit -m "Add read-only wiki CLI option"
+```
+
+---
+
+### Task 2: Wiki Context Helper
+
+**Files:**
+- Create: `code_auditor/wiki.py`
+- Create: `code_auditor/tests/test_wiki_context.py`
+
+- [ ] **Step 1: Write failing wiki helper tests**
+
+Create `code_auditor/tests/test_wiki_context.py` with:
+
+```python
+from __future__ import annotations
+
+from code_auditor.config import AuditConfig
+from code_auditor.wiki import build_wiki_context
+
+
+def test_build_wiki_context_returns_neutral_message_without_wiki() -> None:
+    config = AuditConfig(target="/tmp/project", output_dir="/tmp/output")
+
+    assert build_wiki_context(config, stage=3) == "No wiki knowledge base configured."
+
+
+def test_build_wiki_context_stage2_points_to_decomposition_locations(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    config = AuditConfig(target="/tmp/project", output_dir="/tmp/output", wiki_path=str(wiki))
+
+    context = build_wiki_context(config, stage=2)
+
+    assert f"Wiki root: `{wiki}`" in context
+    assert "read-only" in context
+    assert "index.md" in context
+    assert "attack-surface.md" in context
+    assert "auditing-guide.md" in context
+    assert "entities/" in context
+    assert "triage.json" in context
+
+
+def test_build_wiki_context_stage5_points_to_reproduction_locations(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    config = AuditConfig(target="/tmp/project", output_dir="/tmp/output", wiki_path=str(wiki))
+
+    context = build_wiki_context(config, stage=5)
+
+    assert "reproduction-workflow.md" in context
+    assert "expected evidence" in context
+    assert "entity" in context
+    assert "source" in context
+
+
+def test_build_wiki_context_unknown_stage_uses_generic_guidance(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    wiki = tmp_path / "wiki"
+    wiki.mkdir()
+    config = AuditConfig(target="/tmp/project", output_dir="/tmp/output", wiki_path=str(wiki))
+
+    context = build_wiki_context(config, stage=99)
+
+    assert "index.md" in context
+    assert "Use the wiki only as supporting audit knowledge." in context
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest code_auditor/tests/test_wiki_context.py -v
+```
+
+Expected: import failure for `code_auditor.wiki`.
+
+- [ ] **Step 3: Implement the wiki helper**
+
+Create `code_auditor/wiki.py`:
+
+```python
+from __future__ import annotations
+
+from .config import AuditConfig
+
+NO_WIKI_CONTEXT = "No wiki knowledge base configured."
+
+_GENERIC_GUIDANCE = (
+    "Use the wiki only as supporting audit knowledge. Start with `index.md` if it exists, "
+    "then search root synthesis pages, `entities/`, `concepts/`, and `sources/` for pages "
+    "matching the current component, vulnerability class, or historical pattern."
+)
+
+_STAGE_GUIDANCE: dict[int, str] = {
+    1: (
+        "Stage 1 lookup: start with `index.md` and `overview.md` if present. Search "
+        "`vulnerability-timeline.md` and `sources/` for historical vulnerabilities, dates, "
+        "affected components, root causes, impacts, and attacker profiles. Use root synthesis "
+        "pages to supplement live research, and keep source attribution clear in the research record."
+    ),
+    2: (
+        "Stage 2 lookup: start with `index.md`, `attack-surface.md`, `auditing-guide.md`, "
+        "and `entities/`. Use entity pages to identify components that historically produce "
+        "impactful vulnerabilities. Use concept pages when they help explain why an area is "
+        "selected. Reflect relevant wiki knowledge in `triage.json` rationales and AU `focus` fields."
+    ),
+    3: (
+        "Stage 3 lookup: start from the AU files, then search `entities/` for matching components "
+        "or subsystem names. Search `concepts/` for vulnerability classes suggested by the code path. "
+        "Search `exploit-patterns.md` and matching `sources/` pages for historical bug shapes. "
+        "Use wiki pages as audit heuristics, not proof that this target is vulnerable."
+    ),
+    4: (
+        "Stage 4 lookup: search `concepts/` and relevant `sources/` pages to calibrate "
+        "false-positive checks, impact, and historical severity. Use `vulnerability-timeline.md` "
+        "for broad historical comparison when useful. Do not confirm a vulnerability solely because "
+        "a wiki page describes a similar historical issue; the source data-flow trace is authoritative."
+    ),
+    5: (
+        "Stage 5 lookup: start with `reproduction-workflow.md`. Search matching entity, concept, "
+        "and source pages for realistic trigger models, environment setup, expected evidence, and "
+        "reproduction pitfalls. Use the wiki to choose the lowest reproduction level that preserves "
+        "the vulnerable data flow."
+    ),
+    6: (
+        "Stage 6 lookup: search relevant entity, concept, source, and reproduction pages for clear "
+        "framing and maintainer-facing terminology. Use the wiki to improve report clarity, but keep "
+        "disclosure claims grounded in Stage 5 evidence and the target source. Do not include internal "
+        "wiki links or paths in disclosure artifacts unless they are explicitly useful for the recipient."
+    ),
+}
+
+
+def build_wiki_context(config: AuditConfig, stage: int) -> str:
+    if not config.wiki_path:
+        return NO_WIKI_CONTEXT
+
+    stage_guidance = _STAGE_GUIDANCE.get(stage, _GENERIC_GUIDANCE)
+    return "\n".join([
+        f"Wiki root: `{config.wiki_path}`",
+        "The wiki is read-only. Do not create, edit, move, or delete files in it.",
+        "If a referenced wiki file or directory is absent, skip it and continue with the available pages.",
+        "Prefer `index.md` for navigation when it exists.",
+        stage_guidance,
+    ])
+```
+
+- [ ] **Step 4: Run helper tests again**
+
+Run:
+
+```bash
+pytest code_auditor/tests/test_wiki_context.py -v
+```
+
+Expected: all helper tests pass.
+
+- [ ] **Step 5: Commit helper and helper tests**
+
+Commit the helper and its tests:
+
+```bash
+git add code_auditor/wiki.py code_auditor/tests/test_wiki_context.py
+git commit -m "Add wiki context guidance helper"
+```
+
+---
+
+### Task 3: Backend Additional Directory Access
+
+**Files:**
+- Modify: `code_auditor/agent.py`
+- Modify: `code_auditor/tests/test_backend_selection.py`
+
+- [ ] **Step 1: Write failing additional-directory tests**
+
+Add these tests to `code_auditor/tests/test_backend_selection.py`:
+
+```python
+def test_additional_directories_includes_existing_wiki_path(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    target = tmp_path / "target"
+    output = tmp_path / "output"
+    wiki = tmp_path / "wiki"
+    target.mkdir()
+    output.mkdir()
+    wiki.mkdir()
+    config = AuditConfig(
+        target=str(target),
+        output_dir=str(output),
+        wiki_path=str(wiki),
+    )
+
+    assert agent._additional_directories(config, str(target)) == [
+        str(output.resolve()),
+        str(wiki.resolve()),
+    ]
+
+
+def test_additional_directories_skips_wiki_when_it_is_cwd(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    target = tmp_path / "target"
+    output = tmp_path / "output"
+    target.mkdir()
+    output.mkdir()
+    config = AuditConfig(
+        target=str(target),
+        output_dir=str(output),
+        wiki_path=str(target),
+    )
+
+    assert agent._additional_directories(config, str(target)) == [str(output.resolve())]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest code_auditor/tests/test_backend_selection.py::test_additional_directories_includes_existing_wiki_path code_auditor/tests/test_backend_selection.py::test_additional_directories_skips_wiki_when_it_is_cwd -v
+```
+
+Expected: first test fails because `_additional_directories()` only includes `output_dir`.
+
+- [ ] **Step 3: Update additional-directory logic**
+
+In `code_auditor/agent.py`, replace the loop in `_additional_directories()` with:
+
+```python
+    for candidate in [config.output_dir, config.wiki_path]:
+        if not candidate:
+            continue
+        resolved = os.path.realpath(candidate)
+        if resolved != resolved_cwd and os.path.isdir(resolved) and resolved not in dirs:
+            dirs.append(resolved)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+pytest code_auditor/tests/test_backend_selection.py::test_additional_directories_includes_existing_wiki_path code_auditor/tests/test_backend_selection.py::test_additional_directories_skips_wiki_when_it_is_cwd -v
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add code_auditor/agent.py code_auditor/tests/test_backend_selection.py
+git commit -m "Expose wiki directory to audit agents"
+```
+
+---
+
+### Task 4: Prompt Injection Across Stages
+
+**Files:**
+- Modify: `code_auditor/stages/stage1.py`
+- Modify: `code_auditor/stages/stage2.py`
+- Modify: `code_auditor/stages/stage3.py`
+- Modify: `code_auditor/stages/stage4.py`
+- Modify: `code_auditor/stages/stage5.py`
+- Modify: `code_auditor/stages/stage6.py`
+- Modify: `prompts/stage1.md`
+- Modify: `prompts/stage2.md`
+- Modify: `prompts/stage3.md`
+- Modify: `prompts/stage4.md`
+- Modify: `prompts/stage5.md`
+- Modify: `prompts/stage6.md`
+- Modify or create: `code_auditor/tests/test_wiki_context.py`
+
+- [ ] **Step 1: Write failing prompt-template tests**
+
+Add these imports to `code_auditor/tests/test_wiki_context.py` if they are not already present:
+
+```python
+import pytest
+
+from code_auditor.prompts import PROMPTS_DIR
+```
+
+Add this test to the same file:
+
+```python
+@pytest.mark.parametrize("prompt_name", [
+    "stage1.md",
+    "stage2.md",
+    "stage3.md",
+    "stage4.md",
+    "stage5.md",
+    "stage6.md",
+])
+def test_stage_prompt_templates_have_wiki_context_token(prompt_name: str) -> None:
+    text = (PROMPTS_DIR / prompt_name).read_text()
+
+    assert "## Wiki Knowledge Base" in text
+    assert "__WIKI_CONTEXT__" in text
+```
+
+- [ ] **Step 2: Run prompt-template tests to verify they fail**
+
+Run:
+
+```bash
+pytest code_auditor/tests/test_wiki_context.py::test_stage_prompt_templates_have_wiki_context_token -v
+```
+
+Expected: the test fails for stage prompt templates that do not yet include the wiki section.
+
+- [ ] **Step 3: Add wiki context imports to stage runners**
+
+In each of `code_auditor/stages/stage1.py` through `code_auditor/stages/stage6.py`, add:
+
+```python
+from ..wiki import build_wiki_context
+```
+
+- [ ] **Step 4: Add prompt substitutions**
+
+Add `"wiki_context": build_wiki_context(config, stage=N),` to each `load_prompt()` substitutions dictionary, using the matching stage number.
+
+For Stage 1:
+
+```python
+        "wiki_context": build_wiki_context(config, stage=1),
+```
+
+For Stage 2:
+
+```python
+        "wiki_context": build_wiki_context(config, stage=2),
+```
+
+For Stage 3:
+
+```python
+        "wiki_context": build_wiki_context(config, stage=3),
+```
+
+For Stage 4:
+
+```python
+        "wiki_context": build_wiki_context(config, stage=4),
+```
+
+For Stage 5:
+
+```python
+        "wiki_context": build_wiki_context(config, stage=5),
+```
+
+For Stage 6:
+
+```python
+        "wiki_context": build_wiki_context(config, stage=6),
+```
+
+- [ ] **Step 5: Add wiki sections to prompt templates**
+
+In each prompt template, insert this section after the existing input or user-instructions block and before the workflow-specific instructions:
+
+```markdown
+## Wiki Knowledge Base
+
+__WIKI_CONTEXT__
+```
+
+For `prompts/stage1.md`, insert it after the `## User Instructions` block.
+
+For `prompts/stage2.md`, insert it after the `## User Instructions` block.
+
+For `prompts/stage3.md`, insert it after the assignment paragraphs and before `### Scope of Your Analysis`.
+
+For `prompts/stage4.md`, insert it after the input list and before `## Workflow`.
+
+For `prompts/stage5.md`, insert it after the `## Input` section and before the red-flags table.
+
+For `prompts/stage6.md`, insert it after the `## Input` section and before the red-flags table.
+
+- [ ] **Step 6: Run wiki tests**
+
+Run:
+
+```bash
+pytest code_auditor/tests/test_wiki_context.py -v
+```
+
+Expected: all wiki-context tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add code_auditor/wiki.py code_auditor/tests/test_wiki_context.py code_auditor/stages/stage1.py code_auditor/stages/stage2.py code_auditor/stages/stage3.py code_auditor/stages/stage4.py code_auditor/stages/stage5.py code_auditor/stages/stage6.py prompts/stage1.md prompts/stage2.md prompts/stage3.md prompts/stage4.md prompts/stage5.md prompts/stage6.md
+git commit -m "Inject wiki guidance into audit stages"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Update README common options**
+
+In `README.md`, add this row to the common options table:
+
+```markdown
+| `--wiki` | Read-only LLM wiki knowledge base directory. Each stage searches stage-appropriate wiki pages for audit guidance. |
+```
+
+- [ ] **Step 2: Add README wiki section**
+
+Add this section after the common options table and before the resume/checkpoint paragraph:
+
+````markdown
+### Wiki knowledge base
+
+`--wiki /path/to/wiki` lets CodeAuditor use an existing read-only LLM wiki knowledge base during the audit. Agents may read and search the wiki, but they do not create, edit, or update wiki files.
+
+Recommended structure:
+
+```text
+wiki/
+|-- index.md
+|-- overview.md
+|-- attack-surface.md
+|-- auditing-guide.md
+|-- exploit-patterns.md
+|-- reproduction-workflow.md
+|-- vulnerability-timeline.md
+|-- entities/
+|   `-- <component>.md
+|-- concepts/
+|   `-- <vulnerability-class>.md
+`-- sources/
+    `-- <cve-or-case-study>.md
+```
+
+`index.md` is recommended as the navigation entry point. Partial wikis are supported; stages skip absent files and use the pages that exist.
+````
+
+- [ ] **Step 3: Update README example**
+
+Update the example command to include `--wiki`:
+
+```bash
+code-auditor \
+  --target ~/projects/libfoo \
+  --output-dir ~/audits/libfoo \
+  --wiki ~/knowledge/libfoo-wiki \
+  --max-parallel 4 \
+  --log-level DEBUG
+```
+
+- [ ] **Step 4: Update CLAUDE quick reference**
+
+In `CLAUDE.md`, add this option to the quick reference list:
+
+```markdown
+#   --wiki            Read-only LLM wiki knowledge base directory
+```
+
+- [ ] **Step 5: Run documentation checks**
+
+Run:
+
+```bash
+rg -n -- "--wiki|Wiki knowledge base|read-only LLM wiki" README.md CLAUDE.md
+```
+
+Expected: output includes the README option row, README section heading/content, example command, and CLAUDE quick-reference option.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md CLAUDE.md
+git commit -m "Document wiki knowledge base support"
+```
+
+---
+
+### Task 6: Full Verification
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+pytest code_auditor/tests/test_backend_selection.py code_auditor/tests/test_wiki_context.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run full test suite**
+
+Run:
+
+```bash
+pytest -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Inspect changed files**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intended files are modified or untracked before the final commit. Existing unrelated user edits may still appear; do not revert them.
+
+- [ ] **Step 5: Final commit if verification produced cleanup edits**
+
+If verification required cleanup changes, commit only the files changed for wiki support:
+
+```bash
+git add code_auditor/config.py code_auditor/__main__.py code_auditor/wiki.py code_auditor/agent.py code_auditor/stages/stage1.py code_auditor/stages/stage2.py code_auditor/stages/stage3.py code_auditor/stages/stage4.py code_auditor/stages/stage5.py code_auditor/stages/stage6.py prompts/stage1.md prompts/stage2.md prompts/stage3.md prompts/stage4.md prompts/stage5.md prompts/stage6.md code_auditor/tests/test_backend_selection.py code_auditor/tests/test_wiki_context.py README.md CLAUDE.md
+git commit -m "Finalize wiki knowledge base support"
+```

--- a/docs/superpowers/specs/2026-04-30-wiki-knowledge-base-design.md
+++ b/docs/superpowers/specs/2026-04-30-wiki-knowledge-base-design.md
@@ -1,0 +1,181 @@
+# Read-Only Wiki Knowledge Base Support
+
+## Problem Statement
+
+CodeAuditor currently relies on live project research, git history, source review, and stage outputs. It cannot directly use a maintained LLM-oriented vulnerability wiki such as `/home/bea1e/QEMU-Vuln-Wiki`, even though that wiki contains durable audit knowledge: component risk maps, vulnerability class checklists, historical case studies, attack-surface notes, and reproduction guidance.
+
+The goal is to add a read-only `--wiki` option that lets each audit stage search the most relevant wiki location for the knowledge it needs, without copying the whole wiki into every prompt and without mutating the knowledge base during an audit.
+
+## Decisions
+
+- Add `--wiki PATH` as an optional CLI argument.
+- Store the resolved path in `AuditConfig.wiki_path: str | None`.
+- Validate that `--wiki` points to an existing directory.
+- Treat the wiki as read-only. The pipeline will never scaffold, edit, or update the wiki.
+- Give backend agents filesystem access to the wiki path when it is outside the target or output directories.
+- Inject concise stage-specific wiki guidance into prompts through a shared helper instead of hardcoding QEMU-specific paths in every stage runner.
+- Support the current QEMU wiki shape as the recommended structure, while allowing partial wikis that only contain some of the expected files.
+
+## Recommended Wiki Structure
+
+```text
+wiki/
+├── index.md
+├── overview.md
+├── attack-surface.md
+├── auditing-guide.md
+├── exploit-patterns.md
+├── reproduction-workflow.md
+├── vulnerability-timeline.md
+├── entities/
+│   └── <component>.md
+├── concepts/
+│   └── <vulnerability-class>.md
+└── sources/
+    └── <cve-or-case-study>.md
+```
+
+Roles:
+
+- `index.md`: catalog and first page to read when choosing relevant wiki pages.
+- Root synthesis pages: project-wide audit thesis, attack surface, exploit patterns, reproduction process, and historical trends.
+- `entities/`: component-specific audit maps, such as device models, protocol stacks, parsers, allocators, or storage engines.
+- `concepts/`: vulnerability-class checklists, such as heap overflow, use-after-free, information leak, assertion failure, or denial of service.
+- `sources/`: historical case studies and evidence cards, such as CVEs, advisories, or internal reproductions.
+
+## Architecture
+
+Add a new module, `code_auditor/wiki.py`, responsible for constructing stage-specific guidance text.
+
+Proposed public API:
+
+```python
+def build_wiki_context(config: AuditConfig, stage: int) -> str:
+    ...
+```
+
+If `config.wiki_path` is absent, it returns a short neutral string such as `No wiki knowledge base configured.` If present, it returns:
+
+- the absolute wiki root path;
+- the read-only rule;
+- common lookup rules;
+- stage-specific locations to search first;
+- fallback behavior for missing optional files.
+
+The helper should not read and inline full wiki contents. It should guide agents to search the right locations using their file tools. This preserves context budget and keeps the wiki as the source of truth.
+
+## Stage-Specific Lookup Guidance
+
+Stage 1: Security context research
+
+- Start with `index.md` and `overview.md` if present.
+- Search `vulnerability-timeline.md` and `sources/` for historical vulnerabilities, dates, affected components, root causes, and attacker profiles.
+- Use root synthesis pages to supplement live project research, but keep source attribution clear in the Stage 1 research record.
+
+Stage 2: Codebase decomposition
+
+- Start with `index.md`, `attack-surface.md`, `auditing-guide.md`, and `entities/`.
+- Use entity pages to identify components that historically produce impactful vulnerabilities.
+- Use concept pages only when they help explain why an area is selected for analysis.
+- Reflect relevant wiki knowledge in `triage.json` rationales and AU `focus` fields.
+
+Stage 3: Vulnerability analysis
+
+- Start from the AU files and search `entities/` for matching components or subsystem names.
+- Search `concepts/` for vulnerability classes suggested by the code path.
+- Search `exploit-patterns.md` and matching `sources/` pages for historical bug shapes.
+- Use wiki pages as audit heuristics, not as proof that the current target is vulnerable.
+
+Stage 4: Vulnerability evaluation
+
+- Search `concepts/` and relevant `sources/` pages to calibrate false-positive checks, impact, and historical severity.
+- Use `vulnerability-timeline.md` for broad historical comparison when useful.
+- Do not confirm a vulnerability solely because a wiki page describes a similar historical issue; the source data-flow trace remains authoritative.
+
+Stage 5: PoC reproduction
+
+- Start with `reproduction-workflow.md`.
+- Search matching entity, concept, and source pages for realistic trigger models, environment setup, expected evidence, and reproduction pitfalls.
+- Use the wiki to choose the lowest reproduction level that preserves the vulnerable data flow.
+
+Stage 6: Disclosure preparation
+
+- Search relevant entity, concept, source, and reproduction pages for clear framing and maintainer-facing terminology.
+- Use the wiki to improve report clarity, but keep disclosure claims grounded in Stage 5 evidence and the target source.
+- Do not include internal wiki links or paths in disclosure artifacts unless they are explicitly useful and appropriate for the recipient.
+
+## Prompt Integration
+
+Each stage prompt gets a new `## Wiki Knowledge Base` section populated by a `__WIKI_CONTEXT__` placeholder. Stages without a configured wiki receive the neutral no-wiki message.
+
+Stage runners call `build_wiki_context(config, stage=N)` and pass it to `load_prompt()`.
+
+This keeps prompt behavior explicit and testable without changing the agent contract or output schemas.
+
+## Backend Filesystem Access
+
+Update agent additional-directory handling so the configured wiki path is included alongside the output directory when:
+
+- the path exists;
+- it is not the current working directory;
+- it is not already included.
+
+This matters for wikis outside the target tree, such as `/home/bea1e/QEMU-Vuln-Wiki`.
+
+## CLI And Config
+
+CLI:
+
+```bash
+code-auditor --target /path/to/project --wiki /path/to/wiki
+```
+
+Validation:
+
+- Resolve the path with `os.path.realpath`.
+- Reject missing paths.
+- Reject non-directories.
+- Do not create the path.
+
+Config:
+
+```python
+@dataclass
+class AuditConfig:
+    ...
+    wiki_path: str | None = None
+```
+
+## Testing
+
+Add focused tests for:
+
+- CLI accepts `--wiki`.
+- `main()` resolves and passes `wiki_path` into `AuditConfig`.
+- invalid wiki paths fail before `run_audit()`.
+- `build_wiki_context()` returns a neutral message when no wiki is configured.
+- `build_wiki_context()` returns stage-specific lookup guidance when a wiki is configured.
+- `_additional_directories()` includes the wiki path when it exists and is outside the agent cwd.
+
+No tests should make real agent calls.
+
+## Documentation
+
+Update `README.md` common options with `--wiki`.
+
+Add a short "Wiki Knowledge Base" section explaining:
+
+- the option is read-only;
+- the recommended directory structure;
+- each stage searches the wiki for stage-specific knowledge;
+- partial wikis are allowed, but `index.md` is recommended.
+
+Update `CLAUDE.md` quick reference with the new option.
+
+## Out Of Scope
+
+- Creating or scaffolding a wiki.
+- Updating wiki pages during or after an audit.
+- Building a vector index or embedding search.
+- Injecting full wiki page contents into prompts by default.
+- Changing stage output schemas or validators for wiki citations.

--- a/prompts/stage1.md
+++ b/prompts/stage1.md
@@ -19,6 +19,10 @@ Research the project at **__TARGET_PATH__** and produce three documents:
 
 __USER_INSTRUCTIONS__
 
+## Wiki Knowledge Base
+
+__WIKI_CONTEXT__
+
 ## Workflow
 
 ### Step 1: Security Context Research

--- a/prompts/stage2.md
+++ b/prompts/stage2.md
@@ -14,6 +14,10 @@ This is a targeted vulnerability hunt, not a comprehensive audit. Your goal is t
 
 __USER_INSTRUCTIONS__
 
+## Wiki Knowledge Base
+
+__WIKI_CONTEXT__
+
 ## Auditing Focus
 
 ### Explicit In-Scope and Out-of-Scope Modules

--- a/prompts/stage3.md
+++ b/prompts/stage3.md
@@ -16,6 +16,10 @@ Your primary focus remains the code and concerns described in the analysis unit.
 
 Your task: discover security bugs and vulnerabilities in the assigned codebase.
 
+## Wiki Knowledge Base
+
+__WIKI_CONTEXT__
+
 ## Output
 
 For each confirmed vulnerability, write one JSON file to `__RESULT_DIR__/` named `__FINDING_PREFIX__-F-{NN}.json` (zero-padded: F-01, F-02, ...).

--- a/prompts/stage4.md
+++ b/prompts/stage4.md
@@ -10,6 +10,10 @@ Evaluate one vulnerability finding from Stage 3.
 - **Output file**: `__OUTPUT_PATH__` (write here ONLY if the vulnerability is confirmed and CVSS >= 4.0)
 - **Vulnerability criteria** (bug vs. vulnerability boundary + historical calibration): `__VULN_CRITERIA_PATH__`
 
+## Wiki Knowledge Base
+
+__WIKI_CONTEXT__
+
 ## Workflow
 
 ### Step 1: Read the Finding File

--- a/prompts/stage5.md
+++ b/prompts/stage5.md
@@ -20,6 +20,10 @@ All PoC artifacts (scripts, build outputs, evidence, report) must be written und
 
 Start by reading the vulnerability JSON file to understand the finding details, then proceed to designing the reproduction strategy.
 
+## Wiki Knowledge Base
+
+__WIKI_CONTEXT__
+
 ---
 
 ## Red Flags — STOP If You Catch Yourself Doing These

--- a/prompts/stage6.md
+++ b/prompts/stage6.md
@@ -26,6 +26,10 @@ All disclosure artifacts must be written under:
 
 Start by reading the vulnerability report and PoC artifacts to understand the finding, then proceed through the workflow.
 
+## Wiki Knowledge Base
+
+__WIKI_CONTEXT__
+
 ---
 
 ## Red Flags — STOP If You Catch Yourself Doing These


### PR DESCRIPTION
## Summary
- Add a `--wiki` CLI option and `AuditConfig.wiki_path` for a read-only knowledge base.
- Inject stage-specific wiki guidance into stages 1-6 and make the wiki directory available to agents.
- Document the recommended wiki structure and include design/implementation notes.

## Test Plan
- [x] `pytest -q` (37 passed on `pr/wiki-knowledge-base`)
