### PR TITLE
Require Stage 6 security rationale

### DIFF
--- a/code_auditor/tests/test_parsers_and_report.py
+++ b/code_auditor/tests/test_parsers_and_report.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 
 from code_auditor.parsing.stage2 import parse_au_files, parse_auditing_focus
+from code_auditor.prompts import load_prompt
 from code_auditor.validation.stage2 import (
     DEFAULT_MAX_ANALYSIS_UNITS,
     validate_stage2_au_file,
@@ -12,6 +13,7 @@ from code_auditor.validation.stage2 import (
     validate_triage_file,
 )
 from code_auditor.validation.stage4 import validate_stage4_file
+from code_auditor.validation.stage6 import validate_stage6_disclosure
 
 
 def _write_au(path: str, desc: str, files: list[str], focus: str) -> None:
@@ -260,3 +262,42 @@ def test_stage4_validator_rejects_non_array_propagation_chain():
         assert len(chain_issues) == 1
 
 
+def test_stage6_prompt_requires_target_guidelines_security_rationale() -> None:
+    prompt = load_prompt("stage6.md", {
+        "vuln_report_path": "/tmp/report.md",
+        "poc_dir": "/tmp/poc",
+        "finding_reference": "Finding context",
+        "target_path": "/tmp/target",
+        "disclosure_dir": "/tmp/disclosure",
+        "vuln_id": "H-01",
+    })
+
+    assert "Why This Is a Security Issue" in prompt
+    assert "target security guidelines" in prompt.lower()
+    assert "maintainer" in prompt.lower()
+
+
+def test_stage6_validator_rejects_report_missing_security_rationale_section() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        report_path = os.path.join(tmp, "report.md")
+        with open(report_path, "w", encoding="utf-8") as f:
+            f.write(
+                "# Report\n\n"
+                "## Summary\n\nSummary text.\n\n"
+                "## Severity Assessment\n\nHigh.\n\n"
+                "## Security Impact\n\nImpact text.\n\n"
+                "## Root Cause\n\nRoot cause text.\n\n"
+                "## Reproduction\n\nSteps.\n"
+            )
+        with open(os.path.join(tmp, "email.txt"), "w", encoding="utf-8") as f:
+            f.write("Subject: [Security] Test\n")
+        with open(os.path.join(tmp, "disclosure.zip"), "wb") as f:
+            f.write(b"zip")
+
+        issues = validate_stage6_disclosure(tmp)
+
+    missing = [
+        issue for issue in issues
+        if "Why This Is a Security Issue" in issue.description
+    ]
+    assert len(missing) == 1

--- a/code_auditor/validation/stage6.py
+++ b/code_auditor/validation/stage6.py
@@ -8,6 +8,7 @@ from .common import read_file_or_issues
 
 _REQUIRED_REPORT_SECTIONS = [
     "Summary",
+    "Why This Is a Security Issue",
     "Severity Assessment",
     "Security Impact",
     "Root Cause",

--- a/prompts/stage6.md
+++ b/prompts/stage6.md
@@ -188,8 +188,10 @@ Subject: [Security] <concise description of the vulnerability>
 Hi,
 
 <Opening paragraph: state that you are reporting a security
-vulnerability in [project name], and briefly describethe affected
-component. e.g., "I'm writing to report a ...">
+vulnerability in [project name], and briefly describe the affected
+component. Explain that the reported bug was discovered through
+AI-assisted static code auditing and passed human validation before
+disclosure. e.g., "I'm writing to report a ...">
 
 <Affected versions paragraph: state which versions and modules are
 known to be affected.>
@@ -215,6 +217,7 @@ Regards
 - [ ] Email written to `__DISCLOSURE_DIR__/email.txt`
 - [ ] Plain-text format with lines wrapped at 72 characters
 - [ ] Email communicates the security impact and references `disclosure.zip`
+- [ ] Email states the bug was discovered by AI-assisted static code auditing and passed human validation
 - [ ] No internal audit identifiers
 
 ### Step 5: Package Artifacts

--- a/prompts/stage6.md
+++ b/prompts/stage6.md
@@ -125,6 +125,10 @@ Clear, descriptive title (e.g., "Heap Buffer Overflow in DHCP Option Parsing").
 
 One-paragraph description of the vulnerability: what it is, where it occurs, and its impact.
 
+#### Why This Is a Security Issue
+
+Write a maintainer-facing summary of why this bug qualifies as a security issue from the target security guidelines point of view. Start from the project's explicit security policy, bug bounty scope, in-scope/out-of-scope issue types, and the vulnerability criteria produced during Stage 1. If explicit target security guidelines cover the issue, cite the relevant scope category or rule in plain language. If explicit guidelines are missing or incomplete, use the project's historical vulnerability calibration and the reproduced impact to explain the security boundary. Be concise and concrete: connect attacker-controlled input, affected trust boundary, violated security expectation, and demonstrated impact. Do not overclaim; if the target guidelines only partially support the classification, state that nuance.
+
 #### Severity Assessment
 
 - **CWE Classification**: CWE identifier and name (e.g., CWE-122: Heap-based Buffer Overflow).
@@ -196,6 +200,13 @@ disclosure. e.g., "I'm writing to report a ...">
 <Affected versions paragraph: state which versions and modules are
 known to be affected.>
 
+<Security rationale paragraph: summarize why this bug should be treated
+as a security issue under the target security guidelines. Reference the
+project's explicit scope, bug bounty criteria, or vulnerability criteria
+when available; otherwise summarize the historical calibration and
+reproduced impact. Keep this maintainer-facing and avoid internal audit
+terminology.>
+
 <Impact paragraph: describe the security impact — what an attacker
 could achieve, the severity (reference the CVSS score), and the
 conditions required for exploitation. Focus on why the maintainer
@@ -216,6 +227,7 @@ Regards
 
 - [ ] Email written to `__DISCLOSURE_DIR__/email.txt`
 - [ ] Plain-text format with lines wrapped at 72 characters
+- [ ] Email includes a concise target security guidelines rationale for why the bug is a security issue
 - [ ] Email communicates the security impact and references `disclosure.zip`
 - [ ] Email states the bug was discovered by AI-assisted static code auditing and passed human validation
 - [ ] No internal audit identifiers


### PR DESCRIPTION
## Summary
- Update Stage 6 report and email prompts to include a maintainer-facing security rationale.
- Require a `Why This Is a Security Issue` report section in Stage 6 validation.
- Add tests for the prompt requirement and validator failure mode.

## Test Plan
- [x] `pytest -q` (22 passed on `pr/stage6-security-rationale`)
