### PR TITLE
feat: support auditing local code folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Web server options:
 | `--host` | Bind address; default `0.0.0.0` |
 | `--port` | Listen port; default `8000` |
 
-Audit parameters such as repository, Wiki, backend, model, sandbox mode, parallelism, and output paths are managed in the Web UI and `~/.code_auditor/settings.json`. Run `code-auditor --help` for maintenance commands.
+Audit parameters such as repository, Wiki, backend, model, sandbox mode, parallelism, and output paths are managed in the Web UI and `~/.code_auditor/settings.json`. In **New Audit**, the target can be a managed checkout, a remote Git URL, or a local code folder selected with the native folder picker. Local folders are audited in place without running `git pull`. Run `code-auditor --help` for maintenance commands.
 
 Stage 5 and 6 can use a networked Docker sandbox, a network-isolated Docker sandbox, or a local detached worktree. The Web settings enable Docker choices only after the server passes its Docker, image, disk-space, and Agent runtime checks. Docker is the default; build its image once before an audit reaches reproduction:
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -55,7 +55,7 @@ Web 服务选项：
 | `--host` | 绑定地址；默认 `0.0.0.0` |
 | `--port` | 监听端口；默认 `8000` |
 
-仓库、Wiki、后端、模型、沙箱模式、并行度和输出路径等审计参数统一由 Web 界面和 `~/.code_auditor/settings.json` 管理。维护命令请查看 `code-auditor --help`。
+仓库、Wiki、后端、模型、沙箱模式、并行度和输出路径等审计参数统一由 Web 界面和 `~/.code_auditor/settings.json` 管理。在 **New Audit** 中，审计目标可以是托管 checkout、远程 Git URL，也可以通过系统文件夹选择器选取本地代码目录；本地目录会被原地审计且不会执行 `git pull`。维护命令请查看 `code-auditor --help`。
 
 阶段 5 和 6 可选择联网 Docker 沙箱、断网 Docker 沙箱或宿主机独立 worktree。Web 设置只有在服务端通过 Docker、镜像、磁盘空间和 Agent 运行时检查后，才会启用 Docker 选项。Docker 是默认模式；审计进入复现阶段前，先构建一次镜像：
 

--- a/code_auditor/stages/stage0.py
+++ b/code_auditor/stages/stage0.py
@@ -70,7 +70,7 @@ async def run_setup(config: AuditConfig) -> None:
         await asyncio.to_thread(_git_pull, config.target)
     elif _is_git_repo(config.target):
         logger.info(
-            "Resuming pinned source checkout; skipping git pull for %s.",
+            "Git update disabled; auditing the existing checkout at %s.",
             config.target,
         )
 

--- a/code_auditor/tests/test_web.py
+++ b/code_auditor/tests/test_web.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
 import shutil
 import sqlite3
@@ -1644,6 +1645,8 @@ def test_api_index_serves_html(tmp_path) -> None:
     assert 'id="r-bug-select"' in res.text
     assert 'id="f-repo-select"' in res.text
     assert 'id="f-git-url"' in res.text
+    assert 'id="f-local-directory-path"' in res.text
+    assert 'id="btn-choose-local-directory"' in res.text
     assert 'id="f-wiki-select"' in res.text
     assert res.text.count('name="sandbox-mode"') == 3
     assert 'data-route="cves"' in res.text
@@ -2055,6 +2058,70 @@ def test_api_rejects_custom_target_and_unknown_repository(tmp_path) -> None:
     res = client.post("/api/audit", json={"repository": "github.com/no/such"})
     assert res.status_code == 400
     assert "managed repository" in res.json()["detail"].lower()
+
+
+def test_api_selects_and_starts_audit_for_local_directory(
+    tmp_path, monkeypatch
+) -> None:
+    target = tmp_path / "local-project"
+    target.mkdir()
+    app = _make_app(tmp_path)
+    captured = {}
+
+    monkeypatch.setattr(
+        server_module, "choose_local_directory", lambda: str(target)
+    )
+
+    class FakeJob:
+        @staticmethod
+        def status():
+            return {"state": "starting", "run_id": 7}
+
+    async def fake_start(params):
+        captured["params"] = params
+        return FakeJob()
+
+    monkeypatch.setattr(app.state.manager, "start", fake_start)
+    client = TestClient(app)
+    picker_headers = {"X-CodeAuditor-Token": app.state.terminal_token}
+
+    selection = client.post("/api/local-directories/select", headers=picker_headers)
+    assert selection.status_code == 200
+    assert selection.json()["path"] == str(target.resolve())
+    token = selection.json()["token"]
+
+    response = client.post("/api/audit", json={"local_directory": token})
+    assert response.status_code == 202
+    assert captured["params"].target == str(target.resolve())
+    assert captured["params"].git_url is None
+    assert captured["params"].update_repo is False
+
+    reused = client.post("/api/audit", json={"local_directory": token})
+    assert reused.status_code == 400
+    assert "missing or expired" in reused.json()["detail"]
+
+
+def test_api_local_directory_picker_handles_cancel_and_rejects_root(
+    tmp_path, monkeypatch
+) -> None:
+    app = _make_app(tmp_path)
+    client = TestClient(app)
+    picker_headers = {"X-CodeAuditor-Token": app.state.terminal_token}
+
+    unauthorized = client.post("/api/local-directories/select")
+    assert unauthorized.status_code == 403
+
+    monkeypatch.setattr(server_module, "choose_local_directory", lambda: None)
+    cancelled = client.post(
+        "/api/local-directories/select", headers=picker_headers
+    )
+    assert cancelled.status_code == 200
+    assert cancelled.json() == {"cancelled": True}
+
+    monkeypatch.setattr(server_module, "choose_local_directory", lambda: os.sep)
+    rejected = client.post("/api/local-directories/select", headers=picker_headers)
+    assert rejected.status_code == 400
+    assert "filesystem root" in rejected.json()["detail"]
 
 
 def test_api_job_endpoints_404_for_unknown_run(tmp_path) -> None:
@@ -2676,6 +2743,12 @@ def test_api_audit_rejects_conflicting_or_hidden_configuration(tmp_path) -> None
             "repository": repository,
             "git_url": "https://github.com/user/repo.git",
         },
+    )
+    assert res.status_code == 400
+
+    res = client.post(
+        "/api/audit",
+        json={"repository": repository, "local_directory": "a" * 32},
     )
     assert res.status_code == 400
 

--- a/code_auditor/web/job.py
+++ b/code_auditor/web/job.py
@@ -94,6 +94,7 @@ class JobValidationError(Exception):
 class AuditStartParams:
     target: str | None = None
     git_url: str | None = None
+    update_repo: bool = True
     output_dir: str | None = None
     wiki: str | None = None
     max_parallel: int = 1
@@ -600,6 +601,7 @@ class AuditJob:
             wiki_path=wiki_path,
             max_parallel=params.max_parallel,
             resume=True,
+            update_repo=params.update_repo,
             log_level=params.log_level,
             backend=params.backend,  # type: ignore[arg-type]
             model=self._resolve_model(params),
@@ -636,6 +638,7 @@ class AuditJob:
             wiki_path=wiki_path,
             max_parallel=params.max_parallel,
             resume=True,
+            update_repo=params.update_repo,
             log_level=params.log_level,
             backend=params.backend,  # type: ignore[arg-type]
             model=self._resolve_model(params),

--- a/code_auditor/web/local_directories.py
+++ b/code_auditor/web/local_directories.py
@@ -1,0 +1,104 @@
+"""Native local-directory selection for the Web UI.
+
+The Web frontend cannot learn an absolute filesystem path from a normal HTML
+directory input. CodeAuditor runs on the same machine as the browser, so a
+small platform-native chooser can select a server-local audit target.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+class LocalDirectoryPickerError(RuntimeError):
+    """Raised when a local directory cannot be selected or validated."""
+
+
+class LocalDirectoryPickerUnavailable(LocalDirectoryPickerError):
+    """Raised when no native directory picker is available."""
+
+
+def validate_local_audit_target(path: str) -> str:
+    """Return a canonical, readable local audit directory."""
+    if not isinstance(path, str) or not path or "\x00" in path:
+        raise LocalDirectoryPickerError("The selected local folder is invalid.")
+    expanded = os.path.expanduser(path.strip())
+    if not os.path.isabs(expanded):
+        raise LocalDirectoryPickerError("The selected local folder must be absolute.")
+    resolved = os.path.realpath(expanded)
+    if os.path.dirname(resolved) == resolved:
+        raise LocalDirectoryPickerError(
+            "The filesystem root cannot be used as an audit target."
+        )
+    if not os.path.isdir(resolved):
+        raise LocalDirectoryPickerError(
+            "The selected local folder no longer exists or is not a directory."
+        )
+    if not os.access(resolved, os.R_OK | os.X_OK):
+        raise LocalDirectoryPickerError("The selected local folder is not readable.")
+    return resolved
+
+
+def choose_local_directory() -> str | None:
+    """Open the host's native folder chooser and return its canonical path.
+
+    ``None`` means the user cancelled the dialog. The function is blocking and
+    should be called through ``asyncio.to_thread`` by an async Web endpoint.
+    """
+    if sys.platform == "darwin":
+        command = [
+            "osascript",
+            "-e",
+            'POSIX path of (choose folder with prompt "Select a local code folder to audit")',
+        ]
+    elif os.name == "nt":
+        powershell = shutil.which("powershell.exe") or shutil.which("pwsh.exe")
+        if not powershell:
+            raise LocalDirectoryPickerUnavailable(
+                "No native folder picker is available on this system."
+            )
+        script = (
+            "Add-Type -AssemblyName System.Windows.Forms; "
+            "$dialog = New-Object System.Windows.Forms.FolderBrowserDialog; "
+            "$dialog.Description = 'Select a local code folder to audit'; "
+            "if ($dialog.ShowDialog() -eq 'OK') { $dialog.SelectedPath }"
+        )
+        command = [powershell, "-NoProfile", "-Command", script]
+    else:
+        zenity = shutil.which("zenity")
+        kdialog = shutil.which("kdialog")
+        if zenity:
+            command = [
+                zenity,
+                "--file-selection",
+                "--directory",
+                "--title=Select a local code folder to audit",
+            ]
+        elif kdialog:
+            command = [
+                kdialog,
+                "--getexistingdirectory",
+                os.getcwd(),
+                "--title",
+                "Select a local code folder to audit",
+            ]
+        else:
+            raise LocalDirectoryPickerUnavailable(
+                "No native folder picker is available. Install zenity or kdialog."
+            )
+
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        raise LocalDirectoryPickerUnavailable(
+            f"Could not open the native folder picker: {exc}"
+        ) from exc
+    if result.returncode != 0:
+        # Native pickers use a non-zero exit status for Cancel.
+        return None
+    selected = result.stdout.strip()
+    if not selected:
+        return None
+    return validate_local_audit_target(selected)

--- a/code_auditor/web/server.py
+++ b/code_auditor/web/server.py
@@ -7,13 +7,14 @@ import json
 import os
 import re
 import secrets
+import time
 from contextlib import asynccontextmanager, suppress
 from datetime import date
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlsplit
 
-from fastapi import FastAPI, HTTPException, Query, WebSocket
+from fastapi import FastAPI, Header, HTTPException, Query, WebSocket
 from fastapi.responses import FileResponse, PlainTextResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -36,6 +37,12 @@ from .job import (
     JobConflictError,
     JobValidationError,
     ReproductionStartParams,
+)
+from .local_directories import (
+    LocalDirectoryPickerError,
+    LocalDirectoryPickerUnavailable,
+    choose_local_directory,
+    validate_local_audit_target,
 )
 from .progress import install_web_log_handler
 from .settings import (
@@ -60,6 +67,8 @@ _AGENT_LOG_PATTERNS = (
 )
 
 _REPOSITORY_NAME_PATTERN = r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$"
+_LOCAL_DIRECTORY_TOKEN_PATTERN = r"^[A-Za-z0-9_-]{20,128}$"
+_LOCAL_DIRECTORY_TOKEN_TTL_SECONDS = 10 * 60
 _VULN_ID_PATTERN = r"^[A-Za-z][A-Za-z0-9_-]{0,63}$"
 _DEDUPE_KEY_PATTERN = r"^sha256:[0-9a-f]{64}$"
 DisclosureStatus = Literal[
@@ -83,6 +92,12 @@ class AuditStartRequest(StrictRequest):
         default=None, min_length=1, max_length=512, pattern=_REPOSITORY_NAME_PATTERN
     )
     git_url: str | None = Field(default=None, min_length=1, max_length=2048)
+    local_directory: str | None = Field(
+        default=None,
+        min_length=20,
+        max_length=128,
+        pattern=_LOCAL_DIRECTORY_TOKEN_PATTERN,
+    )
     wiki: str | None = Field(
         default=None, min_length=1, max_length=512, pattern=_REPOSITORY_NAME_PATTERN
     )
@@ -516,6 +531,7 @@ def create_app(
     )
     app.state.manager = manager
     app.state.terminal_token = secrets.token_urlsafe(32)
+    app.state.local_directory_selections = {}
     app.state.active_terminals = 0
     # One process-wide log handler routes records to the owning job's bus.
     install_web_log_handler(manager.bus_for_job)
@@ -647,10 +663,21 @@ def create_app(
 
     @app.post("/api/audit", status_code=202)
     async def start_audit(request: AuditStartRequest) -> dict:
-        if bool(request.repository) == bool(request.git_url):
+        target_choices = sum(
+            bool(value)
+            for value in (
+                request.repository,
+                request.git_url,
+                request.local_directory,
+            )
+        )
+        if target_choices != 1:
             raise HTTPException(
                 status_code=400,
-                detail="Select exactly one existing repository or Git repository URL.",
+                detail=(
+                    "Select exactly one managed repository, Git repository URL, "
+                    "or local code folder."
+                ),
             )
         target = None
         git_url = None
@@ -663,6 +690,19 @@ def create_app(
             target = _resolve_managed_repository(
                 request.repository, settings.repos_dir
             )
+        elif request.local_directory:
+            selection = app.state.local_directory_selections.pop(
+                request.local_directory, None
+            )
+            if selection is None or selection[1] < time.monotonic():
+                raise HTTPException(
+                    status_code=400,
+                    detail="The local folder selection is missing or expired; choose it again.",
+                )
+            try:
+                target = validate_local_audit_target(selection[0])
+            except LocalDirectoryPickerError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
         else:
             try:
                 git_url = validate_remote_repo_url(request.git_url or "")
@@ -675,6 +715,7 @@ def create_app(
                 AuditStartParams(
                     target=target,
                     git_url=git_url,
+                    update_repo=not bool(request.local_directory),
                     wiki=wiki_path,
                     max_parallel=request.max_parallel,
                     backend=settings.backend,
@@ -1007,6 +1048,41 @@ def create_app(
                 for repo in list_cloned_repos(settings.repos_dir)
             ],
         }
+
+    @app.post("/api/local-directories/select")
+    async def select_local_directory(
+        selection_token: str = Header(
+            default="", max_length=128, alias="X-CodeAuditor-Token"
+        ),
+    ) -> dict:
+        """Open a native chooser and issue a short-lived opaque target token."""
+        if not hmac.compare_digest(selection_token, app.state.terminal_token):
+            raise HTTPException(
+                status_code=403,
+                detail="Local folder selection authorization failed.",
+            )
+        try:
+            selected = await asyncio.to_thread(choose_local_directory)
+            if selected is not None:
+                selected = validate_local_audit_target(selected)
+        except LocalDirectoryPickerUnavailable as exc:
+            raise HTTPException(status_code=501, detail=str(exc)) from exc
+        except LocalDirectoryPickerError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if selected is None:
+            return {"cancelled": True}
+
+        now = time.monotonic()
+        selections = app.state.local_directory_selections
+        for token, (_path, expires_at) in list(selections.items()):
+            if expires_at < now:
+                selections.pop(token, None)
+        token = secrets.token_urlsafe(32)
+        selections[token] = (
+            selected,
+            now + _LOCAL_DIRECTORY_TOKEN_TTL_SECONDS,
+        )
+        return {"cancelled": False, "path": selected, "token": token}
 
     @app.get("/api/wikis")
     def list_wikis() -> dict:

--- a/code_auditor/web/static/app.js
+++ b/code_auditor/web/static/app.js
@@ -554,6 +554,10 @@ async function loadRepos() {
       opt.textContent = repo.name;
       select.appendChild(opt);
     }
+    const local = document.createElement("option");
+    local.value = "__local__";
+    local.textContent = "Choose a local code folder…";
+    select.appendChild(local);
     const clone = document.createElement("option");
     clone.value = "__clone__";
     clone.textContent = "Clone a new repository URL…";
@@ -562,6 +566,8 @@ async function loadRepos() {
     // repo list unavailable; the select simply stays empty
   }
 }
+
+let localDirectoryToken = "";
 
 async function loadWikis() {
   const select = $("f-wiki-select");
@@ -584,11 +590,17 @@ async function loadWikis() {
 async function updateRepositoryChoice() {
   const repository = $("f-repo-select").value;
   const cloning = repository === "__clone__";
+  const choosingLocal = repository === "__local__";
   const gitUrlInput = $("f-git-url");
   gitUrlInput.disabled = !cloning;
   gitUrlInput.required = cloning;
   if (!cloning) gitUrlInput.value = "";
-  if (!repository || cloning) {
+  $("f-local-directory-label").hidden = !choosingLocal;
+  if (!choosingLocal) {
+    localDirectoryToken = "";
+    $("f-local-directory-path").value = "";
+  }
+  if (!repository || cloning || choosingLocal) {
     $("repo-runs").hidden = true;
     return;
   }
@@ -596,6 +608,33 @@ async function updateRepositoryChoice() {
 }
 
 $("f-repo-select").addEventListener("change", updateRepositoryChoice);
+
+$("btn-choose-local-directory").addEventListener("click", async () => {
+  const button = $("btn-choose-local-directory");
+  const originalLabel = button.textContent;
+  formError.textContent = "";
+  button.disabled = true;
+  button.textContent = "Choosing…";
+  try {
+    const res = await fetch("/api/local-directories/select", {
+      method: "POST",
+      headers: { "X-CodeAuditor-Token": terminalToken },
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      formError.textContent = data.detail || `Folder picker failed (HTTP ${res.status})`;
+      return;
+    }
+    if (data.cancelled) return;
+    localDirectoryToken = data.token || "";
+    $("f-local-directory-path").value = data.path || "";
+  } catch (error) {
+    formError.textContent = `Folder picker failed: ${error}`;
+  } finally {
+    button.disabled = false;
+    button.textContent = originalLabel;
+  }
+});
 
 // ── New Audit dialog ────────────────────────────────────────────────────────
 const newAuditDialog = $("new-audit-dialog");
@@ -643,7 +682,7 @@ form.addEventListener("submit", async (e) => {
   const repository = $("f-repo-select").value;
   const gitUrl = $("f-git-url").value.trim();
   if (!repository) {
-    formError.textContent = "Select an existing repository or clone a new one.";
+    formError.textContent = "Select a managed repository, local folder, or remote Git URL.";
     return;
   }
   if (repository === "__clone__") {
@@ -652,6 +691,12 @@ form.addEventListener("submit", async (e) => {
       return;
     }
     body.git_url = gitUrl;
+  } else if (repository === "__local__") {
+    if (!localDirectoryToken) {
+      formError.textContent = "Choose a local code folder first.";
+      return;
+    }
+    body.local_directory = localDirectoryToken;
   } else {
     body.repository = repository;
   }

--- a/code_auditor/web/static/index.html
+++ b/code_auditor/web/static/index.html
@@ -148,7 +148,7 @@
     <section class="panel" id="config-panel">
       <h2 id="new-audit-title">New Audit</h2>
       <p class="warning">
-        <strong>Repository update:</strong> Stage 0 runs <code>git pull</code> on the target repository before auditing.
+        <strong>Repository update:</strong> Managed and cloned Git targets run <code>git pull</code> before auditing. Local folders are always audited in place without a Git update.
       </p>
       <form id="audit-form">
         <div class="form-grid">
@@ -156,9 +156,10 @@
             Target repository
             <select id="f-repo-select">
               <option value="">— select a repository —</option>
+              <option value="__local__">Choose a local code folder…</option>
               <option value="__clone__">Clone a new repository URL…</option>
             </select>
-            <span class="hint">Choose a managed checkout or clone a new one.</span>
+            <span class="hint">Choose a managed checkout, a local folder, or clone a remote repository.</span>
           </label>
           <label id="f-git-url-label">
             Git repository URL
@@ -167,6 +168,15 @@
                    pattern="(https://[^ ]+|git@[^ ]+:[^ ]+)"
                    placeholder="https://github.com/user/repo.git" />
             <span class="hint">HTTPS or git@host:path SSH URLs only. Available after choosing "Clone a new repository URL…".</span>
+          </label>
+          <label id="f-local-directory-label" hidden>
+            Local code folder
+            <span class="folder-picker-row">
+              <input type="text" id="f-local-directory-path" readonly
+                     placeholder="No folder selected" />
+              <button type="button" id="btn-choose-local-directory" class="btn">Choose folder…</button>
+            </span>
+            <span class="hint">The selected folder is audited in place; source files are not copied into the managed repository directory.</span>
           </label>
           <label>
             Max parallel agents

--- a/code_auditor/web/static/style.css
+++ b/code_auditor/web/static/style.css
@@ -1486,6 +1486,26 @@ tr.run-row:hover {
   cursor: not-allowed;
 }
 
+.folder-picker-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.folder-picker-row input {
+  flex: 1;
+  min-width: 0;
+}
+
+.folder-picker-row .btn {
+  flex: none;
+  white-space: nowrap;
+}
+
+#f-local-directory-label[hidden] {
+  display: none;
+}
+
 .history-action {
   width: 1%;
   white-space: nowrap;


### PR DESCRIPTION
Adds native local-folder selection to New Audit, secure one-time target tokens, in-place auditing without git pull, documentation, and regression tests.